### PR TITLE
DUPLO-14611: Added Host resource and fixed bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .mypy_cache
 .envrc
 notebooks
+venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ jit = "duplo_resource.jit:DuploJit"
 system = "duplo_resource.system:DuploSystem"
 asg = "duplo_resource.asg:DuploAsg"
 secret = "duplo_resource.secret:DuploSecret"
-config = "duplo_resource.configmap:DuploConfigMap"
+configmap = "duplo_resource.configmap:DuploConfigMap"
+hosts = "duplo_resource.hosts:DuploHosts"
 
 [project.entry-points."formats.duplocloud.net"]
 json = "duplocloud.formats:tojson"

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -14,7 +14,8 @@ class DuploAsg(DuploTenantResource):
   def list(self):
     """Retrieve a list of all services in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"subscriptions/{tenant_id}/GetTenantAsgProfiles")
+    response = self.duplo.get(f"subscriptions/{tenant_id}/GetTenantAsgProfiles")
+    return response.json()
   
   @Command()
   def find(self, 
@@ -56,6 +57,6 @@ class DuploAsg(DuploTenantResource):
     res = self.duplo.post(f"subscriptions/{tenant_id}/UpdateTenantAsgProfile", data)
     return {
       "message": f"Successfully updated asg '{name}'",
-      "data": res
+      "data": res.json()
     }
   

--- a/src/duplo_resource/cronjob.py
+++ b/src/duplo_resource/cronjob.py
@@ -1,5 +1,6 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResource
+from duplocloud.errors import DuploError
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -11,9 +12,14 @@ class DuploCronJob(DuploTenantResource):
   
   @Command()
   def list(self):
-    """Retrieve a list of all services in a tenant."""
+    """Retrieve a list of all cronjob in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob")
+    tenant_name = self.tenant["AccountName"]
+    response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob")
+    if not response.json():
+      raise DuploError(f"No CronJobs found in tenant '{tenant_name}'", 404)
+    else:
+      return response.json()
   
   @Command()
   def find(self, 
@@ -28,7 +34,8 @@ class DuploCronJob(DuploTenantResource):
       DuploError: If the cronjob could not be found.
     """
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob/{name}")
+    response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob/{name}")
+    return response.json()
 
   @Command()
   def update_image(self, 

--- a/src/duplo_resource/cronjob.py
+++ b/src/duplo_resource/cronjob.py
@@ -16,10 +16,10 @@ class DuploCronJob(DuploTenantResource):
     tenant_id = self.tenant["TenantId"]
     tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob")
-    if not response.json():
-      raise DuploError(f"No CronJobs found in tenant '{tenant_name}'", 404)
+    if (data := response.json()):
+      return data
     else:
-      return response.json()
+      raise DuploError(f"No CronJobs found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -14,7 +14,6 @@ class DuploHosts(DuploTenantResource):
   def list(self):
     """Retrieve a list of all hosts in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"subscriptions/{tenant_id}/GetNativeHosts")
     return response.json()
   

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -4,33 +4,33 @@ from duplocloud.errors import DuploError
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
-@Resource("configmap")
-class DuploConfigMap(DuploTenantResource):
+@Resource("hosts")
+class DuploHosts(DuploTenantResource):
   
   def __init__(self, duplo: DuploClient):
     super().__init__(duplo)
   
   @Command()
   def list(self):
-    """Retrieve a list of all configmaps in a tenant."""
+    """Retrieve a list of all hosts in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/configmap")
+    tenant_name = self.tenant["AccountName"]
+    response = self.duplo.get(f"subscriptions/{tenant_id}/GetNativeHosts")
     return response.json()
   
   @Command()
   def find(self, 
            name: args.NAME):
-    """Find a configmap by name.
+    """Find a host by name.
     
     Args:
-      name (str): The name of the configmap to find.
+      name (str): The name of the host to find.
     Returns: 
-      The configmap object.
+      The host object.
     Raises:
-      DuploError: If the configmap could not be found.
+      DuploError: If the host could not be found.
     """
     try:
-      return [s for s in self.list() if s["metadata"]["name"] == name][0]
+        return [s for s in self.list() if s["FriendlyName"] == name][0]
     except IndexError:
-      raise DuploError(f"ConfigMap '{name}' not found", 404)
-
+      raise DuploError(f"Host '{name}' not found", 404)

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -8,6 +8,6 @@ class DuploJit(DuploResource):
     
   @Command()
   def aws(self):
-    """Retrieve a list of all users in the Duplo system."""
+    """Retrieve aws session credentials for current user."""
     sts = self.duplo.get("adminproxy/GetJITAwsConsoleAccessUrl")
-    return sts
+    return sts.json()

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -16,10 +16,10 @@ class DuploLambda(DuploTenantResource):
     tenant_id = self.tenant["TenantId"]
     tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"subscriptions/{tenant_id}/GetLambdaFunctions")
-    if not response.json():
-      raise DuploError(f"No lambda functions found in tenant '{tenant_name}'", 404)
+    if (data := response.json()):
+      return data
     else:
-      return response.json()
+      raise DuploError(f"No lambda functions found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -14,7 +14,12 @@ class DuploLambda(DuploTenantResource):
   def list(self):
     """Retrieve a list of all lambdas in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"subscriptions/{tenant_id}/GetLambdaFunctions")
+    tenant_name = self.tenant["AccountName"]
+    response = self.duplo.get(f"subscriptions/{tenant_id}/GetLambdaFunctions")
+    if not response.json():
+      raise DuploError(f"No lambda functions found in tenant '{tenant_name}'", 404)
+    else:
+      return response.json()
   
   @Command()
   def find(self, 
@@ -48,4 +53,5 @@ class DuploLambda(DuploTenantResource):
       "FunctionName": name,
       "ImageUri": image
     }
-    return self.duplo.post(f"subscriptions/{tenant_id}/UpdateLambdaFunction", data)
+    response = self.duplo.post(f"subscriptions/{tenant_id}/UpdateLambdaFunction", data)
+    return response.json()

--- a/src/duplo_resource/secret.py
+++ b/src/duplo_resource/secret.py
@@ -14,7 +14,12 @@ class DuploSecret(DuploTenantResource):
   def list(self):
     """Retrieve a list of all services in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/secret")
+    tenant_name = self.tenant["AccountName"]
+    response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/secret")
+    if not response.json():
+      raise DuploError(f"No secrets found in tenant '{tenant_name}'", 404)
+    else:
+      return response.json()
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/secret.py
+++ b/src/duplo_resource/secret.py
@@ -16,10 +16,10 @@ class DuploSecret(DuploTenantResource):
     tenant_id = self.tenant["TenantId"]
     tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/secret")
-    if not response.json():
-      raise DuploError(f"No secrets found in tenant '{tenant_name}'", 404)
+    if (data := response.json()):
+      return data
     else:
-      return response.json()
+      raise DuploError(f"No secrets found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -71,7 +71,7 @@ class DuploService(DuploTenantResource):
     tenant_id = self.tenant["TenantId"]
     payload = []
     for i in serviceimage:
-      servicepair = dict([args])
+      servicepair = dict([i])
       for name, image in servicepair.items():
         payloaditem = {}
         service = self.find(name)

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import datetime
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploResource
@@ -13,7 +14,8 @@ class DuploTenant(DuploResource):
   @Command()
   def list(self):
     """Retrieve a list of all tenants in the Duplo system."""
-    return self.duplo.get("adminproxy/GetTenantNames")
+    response = self.duplo.get("adminproxy/GetTenantNames")
+    return response.json()
 
   @Command()
   def find(self, 
@@ -31,11 +33,28 @@ class DuploTenant(DuploResource):
     """Expire a tenant."""
     tenant = self.find(name)
     tenant_id = tenant["TenantId"]
-
+    print("schedule=", schedule)
     # if the schedule not specified then set the date 5 minute from now
     if schedule is None:
       now = datetime.datetime.now() + datetime.timedelta(minutes=5)
       schedule = now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    else:
+      interval, unit = int(schedule[:-1]), schedule[-1]
+      # Calculate the timedelta based on the specified time interval
+      if unit == 'm':
+        delta = timedelta(minutes=interval)
+      elif unit == 'h':
+        delta = timedelta(hours=interval)
+      elif unit == 'd':
+        delta = timedelta(days=interval)
+      else:
+          raise ValueError("Invalid time unit specified. Please use 'm' for minutes, 'h' for hours, or 'd' for days.")
+
+      current_time = datetime.datetime.utcnow()
+      # Calculate the future time after adding the timedelta
+      future_time = current_time + delta
+      # Format the future time in the desired string format
+      schedule = future_time.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
     res = self.duplo.post("adminproxy/UpdateTenantCleanupTimers", {
       "TenantId": tenant_id,
@@ -55,13 +74,15 @@ class DuploTenant(DuploResource):
     tenant = self.find(name)
     tenant_id = tenant["TenantId"]
     # add or update the tenant in the list of enabled tenants
-    log_tenants = self.duplo.get("admin/GetLoggingEnabledTenants")
+    response = self.duplo.get("admin/GetLoggingEnabledTenants")
+    log_tenants = response.json()
     for t in log_tenants:
       if t["TenantId"] == tenant_id:
         t["Enabled"] = enable
         break
     else:
       log_tenants.append({"TenantId": tenant_id, "Enabled": enable})
+    print(log_tenants)
     # update the entire list
     res = self.duplo.post("admin/UpdateLoggingEnabledTenants", log_tenants)
     if res.status_code == 200:

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 import datetime
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploResource
@@ -33,7 +33,6 @@ class DuploTenant(DuploResource):
     """Expire a tenant."""
     tenant = self.find(name)
     tenant_id = tenant["TenantId"]
-    print("schedule=", schedule)
     # if the schedule not specified then set the date 5 minute from now
     if schedule is None:
       now = datetime.datetime.now() + datetime.timedelta(minutes=5)

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -13,7 +13,8 @@ class DuploUser(DuploResource):
   @Command()
   def list(self):
     """Retrieve a list of all users in the Duplo system."""
-    return self.duplo.get("admin/GetAllUserRoles")
+    response = self.duplo.get("admin/GetAllUserRoles")
+    return response.json()
   
   @Command()
   def find(self, 
@@ -25,7 +26,7 @@ class DuploUser(DuploResource):
       raise DuploError(f"User '{name}' not found", 404)
   
   @Command()
-  def add_tenant(self, 
+  def add_user_to_tenant(self, 
                  name: args.NAME, 
                  tenant: args.TENANT):
     """Retrieve a list of all users in the Duplo system."""

--- a/src/duplo_resource/version.py
+++ b/src/duplo_resource/version.py
@@ -17,6 +17,6 @@ class DuploVersion():
     cli = version('duplocloud-client')
     return {
       "cli": cli,
-      "ui": server
+      "ui": server.json()
     }
 

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -37,7 +37,7 @@ class DuploClient():
     self.tenant = tenant
     self.query = query
     self.output = output
-    self.timeout = 10
+    self.timeout = 30
     self.version = version
     self.headers = {
       'Content-Type': 'application/json',
@@ -192,7 +192,7 @@ Client for Duplo at {self.host}
     contentType = response.headers.get('content-type', 'application/json').split(';')[0]
     if 200 <= response.status_code < 300:
       if contentType == 'application/json':
-        return response.json()
+        return response
       elif contentType == 'text/plain':
         return {"message": response.text}
     


### PR DESCRIPTION
## **Type**
Enhancement, Bug fix


___

## **Description**
- Added a new Hosts resource with `list` and `find` methods.
- Improved response handling in various resources (ASG, ConfigMap, CronJob, JIT, Lambda, Secret, Tenant, User, Version) to return JSON response.
- Added error handling for empty response in CronJob, Lambda, and Secret resources.
- Fixed a bug in Service resource where the wrong variable was used in `bulk_update_image` method.
- Renamed `add_tenant` method to `add_user_to_tenant` in User resource.
- Increased the timeout from 10 to 30 in DuploClient.
- Updated project entry-points in `pyproject.toml`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>asg.py</strong><dd><code>Improved response handling in ASG resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/asg.py

- Changed the return type of the `list` and `scale` methods to return <br>  JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-60df692f7342064f0679cc87ffcd78c83f6107e5750ae162e9e446e3e27b7ad8">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.py</strong><dd><code>Improved response handling in ConfigMap resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/configmap.py

- Changed the return type of the `list` method to return JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-31f4cddaf99622814bb1a9e23c6c39cd5d423a2defc34e6e8bb92291a2e17163">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.py</strong><dd><code>Improved response handling and error handling in CronJob resource</code></dd></summary>
<hr>
      
src/duplo_resource/cronjob.py

- Added error handling for empty response in `list` method.
- Changed the return type of the `list` and `find` methods to return <br>  JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-0b1d4f56f53fb4e083445b36ac65806681ab87e4d1c8c6fb5c98026facf4bcaf">+10/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hosts.py</strong><dd><code>Added new Hosts resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/hosts.py

- New file added to handle hosts resource.
- Implemented `list` and `find` methods for hosts resource.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-87656083e440b7e657144ce4ee02bce98d16287e563aacb41bdf1027255ae780">+36/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Improved response handling in JIT resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/jit.py

- Changed the return type of the `aws` method to return JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lambda.py</strong><dd><code>Improved response handling and error handling in Lambda resource</code>&nbsp; </dd></summary>
<hr>
      
src/duplo_resource/lambda.py

- Added error handling for empty response in `list` method.
- Changed the return type of the `list`, `update_image`, and `update_s3` <br>  methods to return JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-e298cb96a0e644b6bbb5ea5e9f56a3155700442153b7e626b918a0004ad34f23">+10/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.py</strong><dd><code>Improved response handling and error handling in Secret resource</code>&nbsp; </dd></summary>
<hr>
      
src/duplo_resource/secret.py

- Added error handling for empty response in `list` method.
- Changed the return type of the `list` method to return JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-cc6c316492d59fdf73e5f7dc29d3f6f7466afb158f49495b551c2673f77eefcd">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tenant.py</strong><dd><code>Improved response handling and added time unit handling in Tenant 

 resource</code></dd></summary>
<hr>
      
src/duplo_resource/tenant.py

- Added handling for different time units in `shutdown` method.
- Changed the return type of the `list`, `logging` methods to return <br>  JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-7065eff8535e2d18fbe9f8011540cf4f22ac22c967e8ebc19e3a9c1601f23419">+24/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>user.py</strong><dd><code>Improved response handling and renamed method in User resource</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/user.py

- Changed the return type of the `list` method to return JSON response.
- Renamed `add_tenant` method to `add_user_to_tenant`.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-1db883fb1de60ca53d2da0d3d774f6121013f7ef1f7fe87b575a03b275a602f4">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version.py</strong><dd><code>Improved response handling in Version resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/version.py

- Changed the return type of the `__call__` method to return JSON <br>  response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-75e0b6d0f0622d5a5e0d8516ec9bc8ea9fb46bba8d63542f29443269b5625f5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Improved response handling and increased timeout in DuploClient</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/client.py

- Increased the timeout from 10 to 30.
- Changed the return type of the `_validate_response` method to return <br>  the response object.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-ed921a2441e8df6f226f7024b875dea79afcd0d87e1326c37b19d232dba3f740">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Fixed bug in Service resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/service.py

- Fixed a bug in `bulk_update_image` method where the wrong variable was <br>  used.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-de4bdab4d945f3f4c737be6a44e3c3c11850f302766a911d4bc30229766398ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated project entry-points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pyproject.toml

- Renamed `config` to `configmap` in project entry-points.
- Added `hosts` to project entry-points.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/24/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
