### PR TITLE
update kubeconfig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,11 @@ where = ["src"]
 duploctl = "duplocloud.cli:main"
 
 [project.entry-points."duplocloud.net"]
+infrastructure = "duplo_resource.infrastructure:DuploInfrastructure"
+tenant = "duplo_resource.tenant:DuploTenant"
 version = "duplo_resource.version:DuploVersion"
 service = "duplo_resource.service:DuploService"
 cronjob = "duplo_resource.cronjob:DuploCronJob"
-tenant = "duplo_resource.tenant:DuploTenant"
 user = "duplo_resource.user:DuploUser"
 lambda = "duplo_resource.lambda:DuploLambda"
 jit = "duplo_resource.jit:DuploJit"

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -1,0 +1,18 @@
+from duplocloud.client import DuploClient
+from duplocloud.resource import DuploResource
+from duplocloud.errors import DuploError
+from duplocloud.commander import Command, Resource
+import duplocloud.args as args
+
+@Resource("infrastructure")
+class DuploInfrastructure(DuploResource):
+  
+  def __init__(self, duplo: DuploClient):
+    super().__init__(duplo)
+
+  @Command()
+  def eks_config(self,
+                 planId: args.PLAN = None):
+    """Retrieve eks session credentials for current user."""
+    res = self.duplo.get(f"v3/admin/plans/{planId}/k8sClusterConfig")
+    return res.json()

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -1,6 +1,5 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploResource
-from duplocloud.errors import DuploError
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -3,6 +3,9 @@ from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 from datetime import datetime, timedelta
+import os
+from pathlib import Path
+import yaml
 
 @Resource("jit")
 class DuploJit(DuploResource):
@@ -20,9 +23,32 @@ class DuploJit(DuploResource):
           planId: args.PLAN = None):
     """Retrieve k8s session credentials for current user."""
     creds = self.duplo.get(f"v3/admin/plans/{planId}/k8sConfig")
-    return self.k8s_exec_credential(creds.json())
+    return self.__k8s_exec_credential(creds.json())
   
-  def k8s_exec_credential(self, creds):
+  @Command()
+  def update_kubeconfig(self,
+                        planId: args.PLAN = None):
+    """Update kubeconfig"""
+    # first get the kubeconfig file and parse it
+    kubeconfig_path = os.environ.get("KUBECONFIG", f"{Path.home()}/.kube/config")
+    kubeconfig = (yaml.safe_load(open(kubeconfig_path, "r")) 
+                  if os.path.exists(kubeconfig_path) 
+                  else self.__empty_kubeconfig())
+    # load the cluster config info
+    infra = self.duplo.load("infrastructure")
+    conf = infra.eks_config(planId)
+    conf["Name"] = conf["Name"].removeprefix("duploinfra-")
+    # add the cluster, user, and context to the kubeconfig
+    self.__add_to_kubeconfig("clusters", self.__cluster_config(conf), kubeconfig)
+    self.__add_to_kubeconfig("users", self.__user_config(conf), kubeconfig)
+    self.__add_to_kubeconfig("contexts", self.__context_config(conf), kubeconfig)
+    kubeconfig["current-context"] = conf["Name"]
+    # write the kubeconfig back to the file
+    with open(kubeconfig_path, "w") as f:
+      yaml.safe_dump(kubeconfig, f)
+    return {"message": f"kubeconfig updated successfully to {kubeconfig_path}"}
+  
+  def __k8s_exec_credential(self, creds):
     expiration = creds.get("LastTokenRefreshTime", datetime.now() + timedelta(seconds=60*55))
     return {
       "kind": "ExecCredential",
@@ -39,4 +65,68 @@ class DuploJit(DuploResource):
         "token": creds["Token"],
         "expirationTimestamp": expiration
       }
+    }
+  
+  def __cluster_config(self, config):
+    """Build a kubeconfig cluster object"""
+    return {
+      "name": config["Name"],
+      "cluster": {
+        "server": config["ApiServer"],
+        "certificate-authority-data": config["CertificateAuthorityDataBase64"]
+      }
+    }
+  
+  def __user_config(self, config):
+    """Build a kubeconfig user object"""
+    return {
+      "name": config["Name"],
+      "user": {
+        "exec": {
+          "apiVersion": "client.authentication.k8s.io/v1beta1",
+          "installHint": """
+Install duploctl for use with kubectl by following
+https://github.com/duplocloud/duploctl
+""",
+          "command": "duploctl",
+          "env": [{
+            "name": "DUPLO_HOST",
+            "value": self.duplo.host
+          },{
+            "name": "DUPLO_TOKEN",
+            "value": self.duplo.headers["Authorization"].split(" ")[1]
+          }],
+          "args": [
+            "jit",
+            "k8s",
+            "--plan",
+            config["Name"]
+          ]
+        }
+      }
+    }
+  
+  def __context_config(self, config):
+    """Build a kubeconfig context object"""
+    return {
+      "name": config["Name"],
+      "context": {
+        "cluster": config["Name"],
+        "user": config["Name"]
+      }
+    }
+  
+  def __add_to_kubeconfig(self, section, item, kubeconfig):
+    """Add an item to a kubeconfig section if it is not already present"""
+    if item not in kubeconfig[section]:
+      kubeconfig[section].append(item)
+
+  def __empty_kubeconfig(self):
+    return {
+      "apiVersion": "v1",
+      "kind": "Config",
+      "preferences": {},
+      "clusters": [],
+      "users": [],
+      "contexts": []
     }

--- a/src/duplo_resource/system.py
+++ b/src/duplo_resource/system.py
@@ -10,5 +10,5 @@ class DuploSystem(DuploResource):
   @Command()
   def info(self):
     """Retrieve all of the system information."""
-    return self.duplo.get("v3/features/system")
+    return self.duplo.get("v3/features/system").json()
   


### PR DESCRIPTION
## **User description**
Try with this: 
```
duploctl jit update_kubeconfig -P nonprod-infra
```

Will create the file if it is not found. Uses the KUBECONFIG environment variable or default location to discover file location.


___

## **Type**
Enhancement


___

## **Description**
This PR primarily focuses on enhancing the functionality of the `DuploJit` and `DuploSystem` classes, and introducing a new `DuploInfrastructure` class. The key changes are:
- A new `DuploInfrastructure` class has been added in `infrastructure.py`, with a method to retrieve EKS session credentials.
- The `DuploJit` class in `jit.py` has been refactored, with the addition of a new `update_kubeconfig` method. This method updates the kubeconfig file with cluster, user, and context information.
- The `info` method in the `DuploSystem` class in `system.py` has been updated to return a JSON response.
- The project entry-points in `pyproject.toml` have been updated, with the addition of `infrastructure`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>infrastructure.py</strong><dd><code>Addition of DuploInfrastructure class and eks_config method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/infrastructure.py

- Added a new class `DuploInfrastructure` which inherits from <br>  `DuploResource`.<br> - Defined a new method `eks_config` to retrieve EKS session credentials <br>  for the current user.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/28/files#diff-e53222fd0a2f91afe3d84ea4b2dd04b60398bd45848ab121c9dcfef6e0844d2c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Refactoring and addition of update_kubeconfig method in DuploJit class</code></dd></summary>
<hr>
      
src/duplo_resource/jit.py

- Refactored the `k8s` method to use a private method <br>  `__k8s_exec_credential`.<br> - Added a new method `update_kubeconfig` to update the kubeconfig file <br>  with cluster, user, and context information.<br> - Added several private methods to build kubeconfig objects and add them <br>  to the kubeconfig file.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/28/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+92/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>system.py</strong><dd><code>Updated info method in DuploSystem class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/system.py

- Updated the `info` method to return JSON response.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/28/files#diff-2668176a25a54bca9f276169ad7c7abdf934e99286e497a56190c92061834856">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated project entry-points in pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pyproject.toml

- Added `infrastructure` to the project entry-points.<br> - Reordered the entry-points.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/28/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
