### PR TITLE
official duplo config for portal context

### DIFF
--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -3,7 +3,7 @@ import requests
 import jmespath
 from cachetools import cached, TTLCache
 from .errors import DuploError
-from .commander import load_service,load_format, Command, get_parser
+from .commander import load_service,load_format, Command, get_parser, get_config_context
 from . import args as t
 
 class DuploClient():
@@ -73,6 +73,12 @@ Client for Duplo at {self.host}
     """
     parser = get_parser(DuploClient.__init__)
     env, args = parser.parse_known_args()
+    # use the duplo config if host or token are not set
+    if not env.host or not env.token:
+      ctx = get_config_context()
+      env.host = ctx.get("host", None)
+      env.token = ctx.get("token", None)
+      env.tenant = ctx.get("tenant", env.tenant)
     return DuploClient(**vars(env)), args
 
   @cached(cache=TTLCache(maxsize=128, ttl=60))

--- a/src/duplocloud/commander.py
+++ b/src/duplocloud/commander.py
@@ -124,10 +124,12 @@ def get_config_context():
   Get the current context from the Duplo config.
   """
   config_path = os.environ.get("DUPLO_CONFIG", f"{Path.home()}/.duplo/config")
-  if not os.path.exists(config_path): raise DuploError("Duplo config not found", 500)
+  if not os.path.exists(config_path): 
+    raise DuploError("Duplo config not found", 500)
   conf = yaml.safe_load(open(config_path, "r"))
   ctx = conf.get("current-context", None)
-  if not ctx: raise DuploError("Duplo context not set, please set context to a portals name", 500)
+  if not ctx: 
+    raise DuploError("Duplo context not set, please set context to a portals name", 500)
   try:
     return [p for p in conf["contexts"] if p["name"] == ctx][0]
   except IndexError:

--- a/src/duplocloud/commander.py
+++ b/src/duplocloud/commander.py
@@ -3,6 +3,9 @@ import argparse
 from importlib.metadata import entry_points
 from .errors import DuploError
 from .argtype import Arg
+import os
+from pathlib import Path
+import yaml
 
 ENTRYPOINT="duplocloud.net"
 FORMATS=f"formats.{ENTRYPOINT}"
@@ -114,3 +117,18 @@ def available_resources():
     A list of available resources names.
   """
   return list(ep.names)
+
+def get_config_context():
+  """Get Config Context
+  
+  Get the current context from the Duplo config.
+  """
+  config_path = os.environ.get("DUPLO_CONFIG", f"{Path.home()}/.duplo/config")
+  if not os.path.exists(config_path): raise DuploError("Duplo config not found", 500)
+  conf = yaml.safe_load(open(config_path, "r"))
+  ctx = conf.get("current-context", None)
+  if not ctx: raise DuploError("Duplo context not set, please set context to a portals name", 500)
+  try:
+    return [p for p in conf["contexts"] if p["name"] == ctx][0]
+  except IndexError:
+    raise DuploError(f"Portal '{ctx}' not found in config", 500)


### PR DESCRIPTION
## **User description**
Now you can set DUPLO_CONFIG and point to a file. Otherwise it deafults to `$HOME/.duplo/config`. 

Here is an example file: 

```yaml
current-context: myportal
contexts:
- name: myportal
  host: https://myportal.duplocloud.net
  token: mytoken
  tenant: mytenant
```


___

## **Type**
Enhancement


___

## **Description**
- This PR introduces enhancements to the `DuploClient` and `commander.py` in the `duplocloud` package.
- The `DuploClient` now uses the Duplo config if the host or token are not set.
- A new method `get_config_context` has been added to `commander.py` to get the current context from the Duplo config.
- The method reads the config file path from the environment variable or defaults to `$HOME/.duplo/config`.
- It raises errors if the config file is not found, the context is not set, or the portal is not found in the config.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Enhancement of DuploClient to use Duplo config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/client.py

- Added a condition to use the Duplo config if host or token are not <br>  set.<br> - The `from_env` method now gets the host, token, and tenant from the <br>  config context if they are not set.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/29/files#diff-ed921a2441e8df6f226f7024b875dea79afcd0d87e1326c37b19d232dba3f740">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commander.py</strong><dd><code>Addition of get_config_context method in commander.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/commander.py

- Added a new method `get_config_context` to get the current context <br>  from the Duplo config.<br> - The method reads the config file path from the environment variable or <br>  defaults to `$HOME/.duplo/config`.<br> - It raises errors if the config file is not found, the context is not `<br>  `set, `<br>  `or `<br>  `the `<br>  `portal `<br>  `is `<br>  `not `<br>  `found `<br>  `in `<br>  `the `<br>  `config.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/29/files#diff-76bc85ae5e9281fbbae1c51d5775fc1663f2b323368722e8bf16a21578a9b9f1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
