### PR TITLE
fixed minor bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ jit = "duplo_resource.jit:DuploJit"
 system = "duplo_resource.system:DuploSystem"
 asg = "duplo_resource.asg:DuploAsg"
 secret = "duplo_resource.secret:DuploSecret"
-configmap = "duplo_resource.configmap:DuploConfigMap"
+config = "duplo_resource.config:DuploConfigMap"
 hosts = "duplo_resource.hosts:DuploHosts"
 ingress = "duplo_resource.ingress:DuploIngress"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ jit = "duplo_resource.jit:DuploJit"
 system = "duplo_resource.system:DuploSystem"
 asg = "duplo_resource.asg:DuploAsg"
 secret = "duplo_resource.secret:DuploSecret"
-config = "duplo_resource.config:DuploConfigMap"
+configmap = "duplo_resource.configmap:DuploConfigMap"
 hosts = "duplo_resource.hosts:DuploHosts"
 ingress = "duplo_resource.ingress:DuploIngress"
 

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -14,8 +14,12 @@ class DuploAsg(DuploTenantResource):
   def list(self):
     """Retrieve a list of all services in a tenant."""
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"subscriptions/{tenant_id}/GetTenantAsgProfiles")
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No Autoscaling group found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/configmap.py
+++ b/src/duplo_resource/configmap.py
@@ -14,8 +14,12 @@ class DuploConfigMap(DuploTenantResource):
   def list(self):
     """Retrieve a list of all configmaps in a tenant."""
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/configmap")
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No Configmaps found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/cronjob.py
+++ b/src/duplo_resource/cronjob.py
@@ -34,8 +34,12 @@ class DuploCronJob(DuploTenantResource):
       DuploError: If the cronjob could not be found.
     """
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob/{name}")
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No CronJob {name} found in tenant '{tenant_name}'", 404)
 
   @Command()
   def update_image(self, 

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -14,8 +14,12 @@ class DuploHosts(DuploTenantResource):
   def list(self):
     """Retrieve a list of all hosts in a tenant."""
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"subscriptions/{tenant_id}/GetNativeHosts")
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No hosts found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -49,12 +49,16 @@ class DuploLambda(DuploTenantResource):
       image (str): The new image to use for the lambda.
     """
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     data = {
       "FunctionName": name,
       "ImageUri": image
     }
     response = self.duplo.post(f"subscriptions/{tenant_id}/UpdateLambdaFunction", data)
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No Lambda Function found in tenant '{tenant_name}'", 404)
 
   @Command()
   def update_s3(self, 
@@ -69,10 +73,14 @@ class DuploLambda(DuploTenantResource):
       s3key (str): The s3 key (file path) to use for the lambda.
     """
     tenant_id = self.tenant["TenantId"]
+    tenant_name = self.tenant["AccountName"]
     data = {
       "FunctionName": name,
       "S3Bucket": bucket,
       "S3Key": key
     }
     response = self.duplo.post(f"subscriptions/{tenant_id}/UpdateLambdaFunction", data)
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No Lambda Function {name} found in tenant '{tenant_name}'", 404)

--- a/src/duplo_resource/secret.py
+++ b/src/duplo_resource/secret.py
@@ -12,7 +12,7 @@ class DuploSecret(DuploTenantResource):
   
   @Command()
   def list(self):
-    """Retrieve a list of all services in a tenant."""
+    """Retrieve a list of all Secrets in a tenant."""
     tenant_id = self.tenant["TenantId"]
     tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/secret")

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -14,7 +14,12 @@ class DuploService(DuploTenantResource):
   def list(self):
     """Retrieve a list of all services in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"subscriptions/{tenant_id}/GetReplicationControllers")
+    tenant_name = self.tenant["AccountName"]
+    response = self.duplo.get(f"subscriptions/{tenant_id}/GetReplicationControllers")
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No service found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/system.py
+++ b/src/duplo_resource/system.py
@@ -1,6 +1,7 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
+from duplocloud.errors import DuploError
 
 @Resource("system")
 class DuploSystem(DuploResource):

--- a/src/duplo_resource/system.py
+++ b/src/duplo_resource/system.py
@@ -10,5 +10,9 @@ class DuploSystem(DuploResource):
   @Command()
   def info(self):
     """Retrieve all of the system information."""
-    return self.duplo.get("v3/features/system")
+    response = self.duplo.get("v3/features/system")
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError("Failed to get system information. Please connect to Adminatrator.", 404)
   

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -18,7 +18,7 @@ class DuploTenant(DuploResource):
     if (data := response.json()):
       return data
     else:
-      raise DuploError(f"No tenants found.", 404)
+      raise DuploError("No tenants found.", 404)
 
   @Command()
   def find(self, 
@@ -93,7 +93,6 @@ class DuploTenant(DuploResource):
         break
     else:
       log_tenants.append({"TenantId": tenant_id, "Enabled": enable})
-    print(log_tenants)
     # update the entire list
     res = self.duplo.post("admin/UpdateLoggingEnabledTenants", log_tenants)
     if res.status_code == 200:

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -15,7 +15,10 @@ class DuploTenant(DuploResource):
   def list(self):
     """Retrieve a list of all tenants in the Duplo system."""
     response = self.duplo.get("adminproxy/GetTenantNames")
-    return response.json()
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No tenants found.", 404)
 
   @Command()
   def find(self, 

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -17,7 +17,7 @@ class DuploUser(DuploResource):
     if (data := response.json()):
       return data
     else:
-      raise DuploError(f"No users found.", 404)
+      raise DuploError("No users found.", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -14,7 +14,11 @@ class DuploUser(DuploResource):
   def list(self):
     """Retrieve a list of all users in the Duplo system."""
     response = self.duplo.get("admin/GetAllUserRoles")
-    return response.json()
+    tenant_name = self.tenant["AccountName"]
+    if (data := response.json()):
+      return data
+    else:
+      raise DuploError(f"No users found in tenant '{tenant_name}'", 404)
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -14,11 +14,10 @@ class DuploUser(DuploResource):
   def list(self):
     """Retrieve a list of all users in the Duplo system."""
     response = self.duplo.get("admin/GetAllUserRoles")
-    tenant_name = self.tenant["AccountName"]
     if (data := response.json()):
       return data
     else:
-      raise DuploError(f"No users found in tenant '{tenant_name}'", 404)
+      raise DuploError(f"No users found.", 404)
   
   @Command()
   def find(self, 


### PR DESCRIPTION
## **Type**
Bug fix, Enhancement


___

## **Description**
- This PR primarily focuses on enhancing error handling in various resource retrieval methods in the `duplo_resource` module.
- It adds tenant name to the response and raises an error when no resource is found in the tenant.
- It also corrects a comment in the `list` method of the `secret` module and updates the entry point for `DuploConfigMap` in `pyproject.toml`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>asg.py</strong><dd><code>Enhanced error handling in Autoscaling group retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/asg.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no Autoscaling group is found in the <br>tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-60df692f7342064f0679cc87ffcd78c83f6107e5750ae162e9e446e3e27b7ad8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.py</strong><dd><code>Enhanced error handling in Configmaps retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/configmap.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no Configmaps are found in the tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-31f4cddaf99622814bb1a9e23c6c39cd5d423a2defc34e6e8bb92291a2e17163">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.py</strong><dd><code>Enhanced error handling in CronJob retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/cronjob.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no CronJob is found in the tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-0b1d4f56f53fb4e083445b36ac65806681ab87e4d1c8c6fb5c98026facf4bcaf">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hosts.py</strong><dd><code>Enhanced error handling in hosts retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/hosts.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no hosts are found in the tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-87656083e440b7e657144ce4ee02bce98d16287e563aacb41bdf1027255ae780">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lambda.py</strong><dd><code>Enhanced error handling in Lambda Function retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/lambda.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no Lambda Function is found in the <br>tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-e298cb96a0e644b6bbb5ea5e9f56a3155700442153b7e626b918a0004ad34f23">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tenant.py</strong><dd><code>Enhanced error handling in tenants retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/tenant.py

- Added error handling for when no tenants are found.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-7065eff8535e2d18fbe9f8011540cf4f22ac22c967e8ebc19e3a9c1601f23419">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>user.py</strong><dd><code>Enhanced error handling in users retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/user.py

<li>Added tenant name to the response.<br> <li> Added error handling for when no users are found in the tenant.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-1db883fb1de60ca53d2da0d3d774f6121013f7ef1f7fe87b575a03b275a602f4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.py</strong><dd><code>Corrected comment in Secrets retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/secret.py

<li>Corrected the comment for the <code>list</code> method to reflect that it retrieves <br>Secrets, not services.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-cc6c316492d59fdf73e5f7dc29d3f6f7466afb158f49495b551c2673f77eefcd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated entry point for DuploConfigMap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pyproject.toml

<li>Changed the entry point for <code>DuploConfigMap</code> from <code>configmap</code> to <code>config</code>.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/30/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
