### PR TITLE
found all the places needing response.json()

### DIFF
--- a/src/duplo_resource/cronjob.py
+++ b/src/duplo_resource/cronjob.py
@@ -1,6 +1,5 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResource
-from duplocloud.errors import DuploError
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -14,12 +13,8 @@ class DuploCronJob(DuploTenantResource):
   def list(self):
     """Retrieve a list of all cronjob in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    tenant_name = self.tenant["AccountName"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/cronJob")
-    if (data := response.json()):
-      return data
-    else:
-      raise DuploError(f"No CronJobs found in tenant '{tenant_name}'", 404)
+    return response.json()
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -14,7 +14,8 @@ class DuploIngress(DuploTenantResource):
   def list(self):
     """Retrieve a list of all ingress in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/ingress")
+    response = self.duplo.get(f"v3/subscriptions/{tenant_id}/k8s/ingress")
+    return response.json()
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -22,8 +22,8 @@ class DuploJit(DuploResource):
   def k8s(self,
           planId: args.PLAN = None):
     """Retrieve k8s session credentials for current user."""
-    creds = self.duplo.get(f"v3/admin/plans/{planId}/k8sConfig")
-    return self.__k8s_exec_credential(creds.json())
+    response = self.duplo.get(f"v3/admin/plans/{planId}/k8sConfig")
+    return self.__k8s_exec_credential(response.json())
   
   @Command()
   def update_kubeconfig(self,

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -45,7 +45,7 @@ class DuploLambda(DuploTenantResource):
     tenant_id = self.tenant["TenantId"]
     self.duplo.post(f"subscriptions/{tenant_id}/CreateLambdaFunction", lambda_fx)
     return {
-      "message": f"Lambda {lambda_fx["FunctionName"]} created"
+      "message": f"Lambda {lambda_fx['FunctionName']} created"
     }
 
   @Command()

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -14,7 +14,8 @@ class DuploService(DuploTenantResource):
   def list(self):
     """Retrieve a list of all services in a tenant."""
     tenant_id = self.tenant["TenantId"]
-    return self.duplo.get(f"subscriptions/{tenant_id}/GetReplicationControllers")
+    response = self.duplo.get(f"subscriptions/{tenant_id}/GetReplicationControllers")
+    return response.json()
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -41,7 +41,3 @@ class DuploUser(DuploResource):
       raise DuploError(f"Failed to add user '{name}' to tenant '{tenant}'", res["status_code"])
     else:
       return f"User '{name}' added to tenant '{tenant}'"
-
-  
-    
-  

--- a/src/duplo_resource/version.py
+++ b/src/duplo_resource/version.py
@@ -19,4 +19,3 @@ class DuploVersion():
       "cli": cli,
       "ui": server.json()
     }
-


### PR DESCRIPTION
## **User description**
This should solve the regressions.


___

## **Type**
enhancement


___

## **Description**
- Simplified JSON response handling in `cronjob.py`, `ingress.py`, `jit.py`, and `service.py` by directly returning the JSON response.
- Fixed a syntax error in the string formatting within the `lambda.py` file.
- Cleaned up formatting by removing unnecessary trailing whitespace and blank lines in `user.py` and `version.py`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cronjob.py</strong><dd><code>Simplify CronJob List Method and Remove Unnecessary Code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/cronjob.py

<li>Simplified the <code>list</code> method to directly return the JSON response.<br> <li> Removed unnecessary error handling and variable <code>tenant_name</code>.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-0b1d4f56f53fb4e083445b36ac65806681ab87e4d1c8c6fb5c98026facf4bcaf">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ingress.py</strong><dd><code>Update Ingress List Method to Return JSON Response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/ingress.py

- Updated the `list` method to directly return the JSON response.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-65cd541c7446f6f21cc348e536972c48c2e664daf2dac9cc40fbb14ccc98b571">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Update JIT k8s Method for Direct JSON Response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/jit.py

- Updated the `k8s` method to directly return the JSON response.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Update Service List Method to Return JSON Response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/service.py

- Updated the `list` method to directly return the JSON response.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-de4bdab4d945f3f4c737be6a44e3c3c11850f302766a911d4bc30229766398ab">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lambda.py</strong><dd><code>Fix Syntax Error in Lambda Create Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/lambda.py

<li>Fixed a syntax error in the string formatting of the <code>create</code> method's <br>return message.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-e298cb96a0e644b6bbb5ea5e9f56a3155700442153b7e626b918a0004ad34f23">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.py</strong><dd><code>Clean Up User Resource File</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/user.py

- Removed trailing whitespace and unnecessary blank lines.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-1db883fb1de60ca53d2da0d3d774f6121013f7ef1f7fe87b575a03b275a602f4">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version.py</strong><dd><code>Remove Trailing Whitespace in Version Resource File</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/version.py

- Removed unnecessary trailing whitespace.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/31/files#diff-75e0b6d0f0622d5a5e0d8516ec9bc8ea9fb46bba8d63542f29443269b5625f5f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
