### PR TITLE
default tenant to none so env var is used

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,3 +21,4 @@ jobs:
     name: Slack notify
     uses: ./.github/workflows/slack-notify.yml
     secrets: inherit
+    needs: [package, image]

--- a/src/duplocloud/args.py
+++ b/src/duplocloud/args.py
@@ -26,6 +26,10 @@ TOKEN = Arg('token', '-t',
             help='The token to authenticate with duplocloud portal api.',
             default=os.getenv('DUPLO_TOKEN', None))
 
+TENANT = Arg("tenant", "-T",
+             help='The tenant name',
+             default=os.getenv('DUPLO_TENANT', "default"))
+
 INTERACTIVE = Arg("interactive","-I", 
               help='Use interactive Login mode for temporary tokens. Do not use with --token.',
               type=bool,
@@ -48,10 +52,6 @@ NOCACHE = Arg("no-cache","--nocache",
 BROWSER = Arg("web-browser","--browser", 
               help='The desired web browser to use for interactive login',
               default=os.getenv('DUPLO_BROWSER', None))
-
-TENANT = Arg("tenant", "-T",
-             help='The tenant name',
-             default=os.getenv('DUPLO_TENANT', "default"))
 
 PLAN = Arg("plan", "-P",
             help='The plan name.',

--- a/src/duplocloud/config.py
+++ b/src/duplocloud/config.py
@@ -15,7 +15,7 @@ class DuploConfig():
   def __init__(self, 
                host: args.HOST=None, 
                token: args.TOKEN=None, 
-               tenant: args.TENANT="default",
+               tenant: args.TENANT=None,
                home_dir: args.HOME_DIR = None, 
                config_file: args.CONFIG = None,
                cache_dir: args.CACHE_DIR = None,

--- a/src/duplocloud/config.py
+++ b/src/duplocloud/config.py
@@ -53,7 +53,7 @@ class DuploConfig():
     self.nocache = nocache
     self.browser = browser
     self.isadmin = isadmin
-    self.tenant = tenant.strip().lower()
+    self.tenant = tenant.strip().lower() if tenant else tenant
     self.query = query.strip() if query else query
     self.output = output.strip()
 


### PR DESCRIPTION
## **User description**
found issue when setting tenant


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Updated the `TENANT` argument in `src/duplocloud/args.py` to fetch its default value from an environment variable, improving flexibility.
- Removed the duplicate `TENANT` argument definition in `src/duplocloud/args.py`, cleaning up the code.
- Modified the default tenant value in `DuploConfig` constructor to `None` to ensure environment variables are used by default.
- Enhanced the GitHub Actions workflow in `.github/workflows/publish.yml` by specifying job dependencies, ensuring proper execution order.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>args.py</strong><dd><code>Refactor TENANT Argument Definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/args.py

<li>Added a new argument <code>TENANT</code> with a default value fetched from <br>environment variable <code>DUPLO_TENANT</code>, defaulting to "default".<br> <li> Removed the duplicate definition of the <code>TENANT</code> argument.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/37/files#diff-10408bee68a44ad34e4226ec91f20e3277d2d637fd8e17d3482fea817838ec96">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>publish.yml</strong><dd><code>Add Job Dependencies in GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/publish.yml

<li>Added a dependency for the <code>slack</code> job on <code>package</code> and <code>image</code> jobs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/37/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Update Default Tenant Value in DuploConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/config.py

<li>Changed the default value of the <code>tenant</code> parameter in <code>DuploConfig</code> <br>constructor from "default" to <code>None</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/37/files#diff-6f9bd6f4b3f482a929bb442adfa0c549a49ec34d1c6fd4929958a88a70de7303">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

