### PR TITLE
k8s and aws caches creds now too

### DIFF
--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -3,7 +3,6 @@ from duplocloud.errors import DuploExpiredCache
 from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
-from datetime import datetime, timedelta
 import os
 from pathlib import Path
 import yaml

--- a/src/duplocloud/config.py
+++ b/src/duplocloud/config.py
@@ -235,7 +235,7 @@ class DuploConfig():
     """
     c = self.get_cached_item(key)
     if (exp := c.get("Expiration", None)) and (t := c.get("DuploToken", None)):
-      if exp > datetime.datetime.now().isoformat():
+      if not self.expired(exp):
         return t
     raise DuploExpiredCache(key)
   
@@ -272,15 +272,44 @@ class DuploConfig():
       The cache key as a string.
     """
     h = self.host.split("://")[1]
-    k = f"{h},{name}"
+    parts = [h]
     if self.isadmin:
-      k = f"{k},admin"
-    return k
+      parts.append("admin")
+    parts.append(name)
+    return ",".join(parts)
+  
+  def expiration(self, hours: int = 6):
+    """Expiration
+    
+    Get the expiration time for the given number of hours. This is a simple calculation of the current time plus the number of hours.
+
+    Args:
+      hours: The number of seconds to add to the current time.
+
+    Returns:
+      The expiration time as a string.
+    """
+    return (datetime.datetime.now() + datetime.timedelta(hours=hours)).isoformat()
+  
+  def expired(self, exp: str = None):
+    """Expired
+    
+    Check if the given expiration time is expired. This is a simple comparison of the current time and the expiration time.
+
+    Args:
+      exp: The expiration time to check.
+
+    Returns:
+      True if the expiration time is in the past, False otherwise.
+    """
+    if exp is None:
+      return True
+    return datetime.datetime.now() > datetime.datetime.fromisoformat(exp)
 
   def __token_cache(self, token, otp=False):
     return {
       "Version": "v1",
       "DuploToken": token,
-      "Expiration": (datetime.datetime.now() + datetime.timedelta(hours=6)).isoformat(),
+      "Expiration": self.expiration(),
       "NeedOTP": otp
     }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced expiration handling for AWS and Kubernetes credentials caching to ensure freshness of cached credentials.
- Enhanced cache key generation for Kubernetes credentials to be more specific by including `planId`.
- Added new methods in `config.py` to support expiration checks and dynamic expiration time calculation for cached items.
- Improved cache management by refining cache key generation and utilizing expiration handling for better cache validity.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Enhance Credentials Caching with Expiration Handling for AWS and </code><br><code>Kubernetes</code></dd></summary>
<hr>
      
src/duplo_resource/jit.py

<li>Added expiration check and handling for AWS and Kubernetes (k8s) <br>credentials cache.<br> <li> Updated cache key generation for Kubernetes credentials to include <br><code>planId</code>.<br> <li> Introduced <code>DuploExpiredCache</code> exception handling to refresh expired <br>credentials.<br> <li> Modified <code>__k8s_exec_credential</code> method to use dynamic expiration and <br>interactive config.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/38/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Implement Expiration Handling and Improve Cache Management in Config</code></dd></summary>
<hr>
      
src/duplocloud/config.py

<li>Implemented <code>expired</code> method to check if cached items are expired based <br>on current time.<br> <li> Updated <code>cached_token</code> method to use <code>expired</code> method for expiration <br>check.<br> <li> Added <code>expiration</code> method to calculate expiration time for cached items.<br> <li> Refined <code>cache_key_for</code> method to improve cache key generation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/38/files#diff-6f9bd6f4b3f482a929bb442adfa0c549a49ec34d1c6fd4929958a88a70de7303">+34/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

