### PR TITLE
aws and k8s config fun

### DIFF
--- a/src/duplocloud/config.py
+++ b/src/duplocloud/config.py
@@ -319,6 +319,31 @@ class DuploConfig():
     if exp is None:
       return True
     return datetime.datetime.now() > datetime.datetime.fromisoformat(exp)
+  
+  def build_command(self, *args):
+    """Context Args
+    
+    Build a comamnd using the current context. 
+
+    Returns:
+      The context args as a dict.
+    """
+    cmd = list(args)
+    cmd.append("--host")
+    cmd.append(self.host)
+    if self.interactive:
+      cmd.append("--interactive")
+      if self.isadmin:
+        cmd.append("--isadmin")
+      if self.nocache:
+        cmd.append("--nocache")
+      if self.browser:
+        cmd.append("--browser")
+        cmd.append(self.browser)
+    else:
+      cmd.append("--token")
+      cmd.append(self.token)
+    return cmd
 
   def __token_cache(self, token, otp=False):
     return {


### PR DESCRIPTION
## **User description**
also open aws console in browser ;)

# AWS  Config
Run this to make a profile
```sh
duploctl jit update_aws_config qa-aws --interactive
```
Try it out with this:  
```sh
aws s3 ls --profile qa-aws
```


## k8s Config
You can do this: 
```sh
duploctl jit update_kubeconfig --plan test01 --ctx qa-aws  
```
then run this to check that it works
```sh
kubectl get nodes
```

## Opens AWS Console

```sh
duploctl jit web --ctx qa-aws
```


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Added support for bypassing cache when retrieving AWS session credentials.
- Fixed format issues with AWS credentials and Kubernetes credentials by removing problematic fields.
- Introduced a new command to update AWS CLI configuration with JIT credentials.
- Implemented functionality to open AWS console in the browser directly from the command line.
- Enhanced command construction to include context-specific arguments, improving integration with other tools.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Enhancements and Fixes in JIT AWS and Kubernetes Configuration</code></dd></summary>
<hr>
      
src/duplo_resource/jit.py

<li>Added <code>nocache</code> parameter to <code>aws</code> command for bypassing cache.<br> <li> Removed <code>Expiration</code> from AWS credentials and <code>expirationTimestamp</code> from <br>Kubernetes credentials to fix format issues.<br> <li> Implemented <code>update_aws_config</code> command to update AWS CLI configuration.<br> <li> Added <code>web</code> command to open AWS console in the browser.<br> <li> Modified <code>__user_config</code> to use <code>build_command</code> for constructing command <br>arguments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/40/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+46/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Implement Context-Aware Command Building in Configuration</code></dd></summary>
<hr>
      
src/duplocloud/config.py

<li>Implemented <code>build_command</code> method to construct commands with current <br>context.<br> <li> Added handling for additional flags like <code>--interactive</code>, <code>--isadmin</code>, <br><code>--nocache</code>, and <code>--browser</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/40/files#diff-6f9bd6f4b3f482a929bb442adfa0c549a49ec34d1c6fd4929958a88a70de7303">+25/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

