### PR TITLE
let it run manually to debug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Releaser
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   releaser:
@@ -21,30 +22,6 @@ jobs:
         echo "GIT_TAG=${GIT_TAG}" >> $GITHUB_OUTPUT
         echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
         echo "NAME=${NAME}" >> $GITHUB_OUTPUT
-
-    - name: Build Release Message
-      id: message
-      env:
-        GIT_TAG: ${{ steps.set_tag.outputs.GIT_TAG }}
-        VERSION: ${{ steps.set_tag.outputs.VERSION }}
-      run: |
-        MESSAGE="$(cat <<EOF
-        duploctl ${GIT_TAG} is out!. 
-
-        PyPi: 
-        [duplocloud-client](https://pypi.org/project/duplocloud-client/${VERSION}/)
-        ```sh
-        pip install duplocloud-client==${VERSION}
-        ```
-
-        Dockerhub:  
-        [duplocloud/duploctl:${GIT_TAG}](https://hub.docker.com/r/duplocloud/duploctl)
-        ```sh
-        docker pull duplocloud/duploctl:${GIT_TAG}
-        ```
-        EOF
-        )"
-        echo "MESSAGE=${MESSAGE}" >> $GITHUB_OUTPUT
     
     - name: Download Artifacts
       uses: actions/download-artifact@v4
@@ -69,8 +46,21 @@ jobs:
       with:
         files: |
           dist/*
-        body: ${{ steps.message.outputs.MESSAGE }}
-        prerelease: ${{ github.event.inputs.prerelease }}
+        body: |
+          duploctl ${{ steps.set_tag.outputs.GIT_TAG }} is out!. 
+
+          PyPi: 
+          [duplocloud-client](https://pypi.org/project/duplocloud-client/${{ steps.set_tag.outputs.VERSION }}/)
+          ```sh
+          pip install duplocloud-client==${{ steps.set_tag.outputs.VERSION }}
+          ```
+
+          Dockerhub:  
+          [duplocloud/duploctl:${{ steps.set_tag.outputs.GIT_TAG }}](https://hub.docker.com/r/duplocloud/duploctl)
+          ```sh
+          docker pull duplocloud/duploctl:${{ steps.set_tag.outputs.GIT_TAG }}
+          ```
+        prerelease: false
 
     - name: Post to a Slack channel
       id: slack
@@ -85,6 +75,14 @@ jobs:
 
     - name: Job Summary
       env:
-        MESSAGE: ${{ steps.message.outputs.MESSAGE }}
-      run: echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
+        GIT_TAG: ${{ steps.set_tag.outputs.GIT_TAG }}
+        URL: ${{ steps.release.outputs.url }}
+        VERSION: ${{ steps.set_tag.outputs.VERSION }}
+      run: |
+        cat <<EOF >> $GITHUB_STEP_SUMMARY
+        Tag: $GIT_TAG
+        Release: $URL
+        Docker: duplocloud/duploctl:${GIT_TAG}
+        PyPi: duplocloud-client==${VERSION}
+        EOF
     


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a manual trigger option to allow running the release workflow manually for debugging purposes.
- Simplified the release message generation process by removing the separate step and integrating the message directly into the asset upload step.
- By default, releases are now marked as final (not prerelease).
- Improved job summary to include detailed release information, including tag, release URL, Docker, and PyPi details.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Enhance Release Workflow and Simplify Release Message Generation</code></dd></summary>
<hr>
      
.github/workflows/release.yml

<li>Added manual trigger option <code>workflow_dispatch</code> to the workflow.<br> <li> Simplified the release message generation by integrating it directly <br>into the <code>Upload Release Asset</code> step.<br> <li> Set <code>prerelease</code> flag to false by default.<br> <li> Enhanced the <code>Job Summary</code> step to include more detailed information <br>about the release.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/49/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+26/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

