### PR TITLE
fixed issues with aks jit

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -43,7 +43,7 @@ jobs:
       id: build_image
       uses: duplocloud/actions/build-image@main
       with:
-        platforms: linux/amd64 # ,linux/arm64 # makes it take longer
+        platforms: linux/amd64,linux/arm64 # makes it take longer
         push: ${{ inputs.push }}
         docker-username: ${{ secrets.DOCKER_USERNAME }}
         docker-password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches:
       - main
-  push: 
-    paths:
-      - 'src/**'
 
 jobs:
   test:

--- a/installer.spec
+++ b/installer.spec
@@ -1,30 +1,23 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
 
+# Add all the resources as hidden imports
+directory = 'src/duplo_resource'
+hi =[
+  'duplocloud.formats',
+  'duplo_resource'
+]
+for filename in os.listdir(directory):
+  if filename != '__init__.py' and not os.path.isdir(f"{directory}/{filename}"):
+    m = filename.split('.')[0]
+    hi.append(f'duplo_resource.{m}')
 
 a = Analysis(
     ['src/duplocloud/cli.py'],
     pathex=[],
     binaries=[],
     datas=[],
-    hiddenimports=[
-        'duplocloud.formats',
-        'duplo_resource',
-        'duplo_resource.asg',
-        'duplo_resource.configmap',
-        'duplo_resource.cronjob',
-        'duplo_resource.ecs_service',
-        'duplo_resource.hosts',
-        'duplo_resource.infrastructure',
-        'duplo_resource.ingress',
-        'duplo_resource.jit',
-        'duplo_resource.lambda',
-        'duplo_resource.secret',
-        'duplo_resource.service',
-        'duplo_resource.system',
-        'duplo_resource.tenant',
-        'duplo_resource.user',
-        'duplo_resource.version',
-    ],
+    hiddenimports=hi,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -120,17 +120,17 @@ class DuploJit(DuploResource):
     }
   
   def __k8s_exec_credential(self, creds):
-    c = {
+    cluster = {
       "server": creds["ApiServer"],
       "config": None
     }
     if creds["K8Provider"] == 0 and (ca := creds.get("CertificateAuthorityDataBase64", None)):
-      c["certificate-authority-data"] = ca
+      cluster["certificate-authority-data"] = ca
     return {
       "kind": "ExecCredential",
       "apiVersion": "client.authentication.k8s.io/v1beta1",
       "spec": {
-        "cluster": c,
+        "cluster": cluster,
         "interactive": False
       },
       "status": {
@@ -141,16 +141,16 @@ class DuploJit(DuploResource):
   
   def __cluster_config(self, config):
     """Build a kubeconfig cluster object"""
-    c = {
+    cluster = {
       "server": config["ApiServer"]
     }
     if config["K8Provider"] == 0 and (ca := config.get("CertificateAuthorityDataBase64", None)):
-      c["certificate-authority-data"] = ca
+      cluster["certificate-authority-data"] = ca
     elif config["K8Provider"] == 1:
-      c["insecure-skip-tls-verify"] = True
+      cluster["insecure-skip-tls-verify"] = True
     return {
       "name": config["Name"],
-      "cluster": c
+      "cluster": cluster
     }
   
   def __user_config(self, config):

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -120,15 +120,17 @@ class DuploJit(DuploResource):
     }
   
   def __k8s_exec_credential(self, creds):
+    c = {
+      "server": creds["ApiServer"],
+      "config": None
+    }
+    if creds["K8Provider"] == 0 and (ca := creds.get("CertificateAuthorityDataBase64", None)):
+      c["certificate-authority-data"] = ca
     return {
       "kind": "ExecCredential",
       "apiVersion": "client.authentication.k8s.io/v1beta1",
       "spec": {
-        "cluster": {
-          "server": creds["ApiServer"],
-          "certificate-authority-data": creds["CertificateAuthorityDataBase64"],
-          "config": None
-        },
+        "cluster": c,
         "interactive": False
       },
       "status": {
@@ -139,12 +141,16 @@ class DuploJit(DuploResource):
   
   def __cluster_config(self, config):
     """Build a kubeconfig cluster object"""
+    c = {
+      "server": config["ApiServer"]
+    }
+    if config["K8Provider"] == 0 and (ca := config.get("CertificateAuthorityDataBase64", None)):
+      c["certificate-authority-data"] = ca
+    elif config["K8Provider"] == 1:
+      c["insecure-skip-tls-verify"] = True
     return {
       "name": config["Name"],
-      "cluster": {
-        "server": config["ApiServer"],
-        "certificate-authority-data": config["CertificateAuthorityDataBase64"]
-      }
+      "cluster": c
     }
   
   def __user_config(self, config):

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -456,7 +456,7 @@ Client for Duplo at {self.host}
     Returns:
       The cache key as a string.
     """
-    h = self.host.split("://")[1]
+    h = self.host.split("://")[1].replace("/", "")
     parts = [h]
     if self.isadmin:
       parts.append("admin")


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced Kubernetes configuration handling in `jit.py` to conditionally include `certificate-authority-data` or `insecure-skip-tls-verify` based on the `K8Provider` value.
- Fixed an issue in `client.py` where the cache key generation could include slashes from the host URL, potentially leading to incorrect cache keys.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Enhance Kubernetes Configuration Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplo_resource/jit.py

<li>Refactored <code>__k8s_exec_credential</code> and <code>__cluster_config</code> methods to <br>support conditional inclusion of <code>certificate-authority-data</code> or <br><code>insecure-skip-tls-verify</code>.<br> <li> Added a condition to include <code>certificate-authority-data</code> if <code>K8Provider</code> <br>is 0 and it exists.<br> <li> Added a condition to include <code>insecure-skip-tls-verify</code> if <code>K8Provider</code> is <br>1.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/52/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+15/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Fix Cache Key Generation in Client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/duplocloud/client.py

<li>Modified <code>cache_key_for</code> method to ensure the host part of the URL does <br>not include slashes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/52/files#diff-ed921a2441e8df6f226f7024b875dea79afcd0d87e1326c37b19d232dba3f740">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

