### PR TITLE
expiration format issue fix

### DIFF
--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -25,24 +25,24 @@ class DuploJit(DuploResource):
 
     # check if admin or choose tenant
     if self.duplo.isadmin:
-        path = "adminproxy/GetJITAwsConsoleAccessUrl"
+      path = "adminproxy/GetJITAwsConsoleAccessUrl"
     else:
-        t = self.duplo.load("tenant")
-        tenant = t.find(self.duplo.tenant)
-        path = f"subscriptions/{tenant['TenantId']}/GetAwsConsoleTokenUrl"
-    
+      t = self.duplo.load("tenant")
+      tenant = t.find(self.duplo.tenant)
+      path = f"subscriptions/{tenant['TenantId']}/GetAwsConsoleTokenUrl"
+
     # try and get those creds
     try:
-        if nc:
-            sts = self.duplo.get(path).json()
-        else:
-            sts = self.duplo.get_cached_item(k)
-            if self.duplo.expired(sts.get("Expiration", None)):
-                raise DuploExpiredCache(k)
-    except DuploExpiredCache:
+      if nc:
         sts = self.duplo.get(path).json()
-        sts["Expiration"] = self.duplo.expiration()
-        self.duplo.set_cached_item(k, sts)
+      else:
+        sts = self.duplo.get_cached_item(k)
+        if self.duplo.expired(sts.get("Expiration", None)):
+          raise DuploExpiredCache(k)
+    except DuploExpiredCache:
+      sts = self.duplo.get(path).json()
+      sts["Expiration"] = self.duplo.expiration()
+      self.duplo.set_cached_item(k, sts)
 
     # Convert expiration timestamp to aware datetime object with timezone info
     expiration_timestamp = datetime.datetime.fromisoformat(sts["Expiration"])
@@ -176,11 +176,11 @@ class DuploJit(DuploResource):
 
   def __k8s_exec_credential(self, ctx):
     cluster = {
-        "server": ctx["ApiServer"],
-        "config": None
+      "server": ctx["ApiServer"],
+      "config": None
     }
     if ctx["K8Provider"] == 0 and (ca := ctx.get("CertificateAuthorityDataBase64", None)):
-        cluster["certificate-authority-data"] = ca
+      cluster["certificate-authority-data"] = ca
 
     # Parse expiration timestamp string to datetime object
     expiration_timestamp = datetime.datetime.fromisoformat(self.duplo.expiration())
@@ -189,18 +189,18 @@ class DuploJit(DuploResource):
     formatted_expiration = expiration_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return {
-        "kind": "ExecCredential",
-        "apiVersion": "client.authentication.k8s.io/v1beta1",
-        "spec": {
-            "cluster": cluster,
-            "interactive": False
-        },
-        "status": {
-            "token": ctx["Token"],
-            "expirationTimestamp": formatted_expiration
-        }
+      "kind": "ExecCredential",
+      "apiVersion": "client.authentication.k8s.io/v1beta1",
+      "spec": {
+        "cluster": cluster,
+        "interactive": False
+      },
+      "status": {
+        "token": ctx["Token"],
+        "expirationTimestamp": formatted_expiration
+      }
     }
-  
+
   def __cluster_config(self, ctx):
     """Build a kubeconfig cluster object"""
     cluster = {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Corrected the formatting of expiration timestamps for AWS CLI and Kubernetes credentials to ensure compatibility.
- Introduced `datetime` usage for handling timezone-aware datetime objects, improving the reliability of timestamp formatting.
- Enhanced the `aws` method to correctly format the expiration timestamp as expected by AWS CLI.
- Updated the `__k8s_exec_credential` method to format the expiration timestamp correctly for Kubernetes credentials.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Correct Expiration Timestamp Formatting for AWS CLI and Kubernetes </code><br><code>Credentials</code></dd></summary>
<hr>
      
src/duplo_resource/jit.py

<li>Added import for <code>datetime</code> to handle expiration timestamps.<br> <li> Updated the <code>aws</code> method to format the expiration timestamp correctly <br>for AWS CLI.<br> <li> Added conversion of expiration timestamp to a timezone-aware datetime <br>object in both <code>aws</code> and <code>__k8s_exec_credential</code> methods.<br> <li> Formatted the expiration timestamp to match the expected format for <br>AWS CLI and Kubernetes credentials.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/67/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+46/-34</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

