### PR TITLE
removing tenant arg, adding remove_user_from_tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+ - remove_user_from_tenant command
+
+### Updates 
+ - changed handling of tenant arg in user resource
+ - add reference yaml for users
+
 ## [0.2.31] - 2024-07-29
 
 ### Added 

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -27,8 +27,7 @@ class DuploUser(DuploResource):
   
   @Command()
   def add_user_to_tenant(self, 
-                 name: args.NAME, 
-                 tenant: args.TENANT) -> dict:
+                 name: args.NAME) -> dict:
     """Add User to Tenant
     
     Usage: CLI Usage
@@ -43,7 +42,7 @@ class DuploUser(DuploResource):
     Returns:
       message: A message indicating the user was added to the tenant.
     """
-    tenant_id = self.tenent_svc.find(tenant)["TenantId"]
+    tenant_id = self.tenent_svc.find(self.duplo.tenant)["TenantId"]
     res = self.duplo.post("admin/UpdateUserAccess", {
       "Policy": { "IsReadOnly": None },
       "Username": name,
@@ -51,9 +50,40 @@ class DuploUser(DuploResource):
     })
     # check http response is 204
     if res.status_code != 204:
-      raise DuploError(f"Failed to add user '{name}' to tenant '{tenant}'", res["status_code"])
+      raise DuploError(f"Failed to add user '{name}' to tenant '{self.duplo.tenant}'", res["status_code"])
     else:
-      return f"User '{name}' added to tenant '{tenant}'"
+      return f"User '{name}' added to tenant '{self.duplo.tenant}'"
+    
+  @Command()
+  def remove_user_from_tenant(self, 
+                 name: args.NAME) -> dict:
+    """Remove a User from a Tenant
+    
+    Usage: CLI Usage
+      ```sh
+      duploctl user remove_user_from_tenant <user> --tenant <tenant_name>
+      ```
+
+    Args:
+      name: The name of the user to remove from the tenant.
+      tenant: The name of the tenant to remove the user from.
+
+    Returns:
+      message: A message indicating the user was removed from the tenant.
+    """
+    tenant_id = self.tenent_svc.find(self.duplo.tenant)["TenantId"]
+    res = self.duplo.post("admin/UpdateUserAccess", {
+      "Policy": {},
+      "Username": name,
+      "TenantId": tenant_id,
+      "State": "deleted"
+    })
+
+    # check http response is 204
+    if res.status_code != 204:
+      raise DuploError(f"Failed to remove user '{name}' from tenant '{self.duplo.tenant}'", res["status_code"])
+    else:
+      return f"User '{name}' removed from tenant '{self.duplo.tenant}'"
     
   @Command()
   def create(self, 

--- a/src/tests/data/user.yaml
+++ b/src/tests/data/user.yaml
@@ -1,0 +1,13 @@
+Username: nobody@example.com
+Roles:
+- User
+VpnPassword: "********"
+ApiTokens: []
+IsReadOnly: false
+IsVpnConfigCreated: false
+IsVpnConfigUpdated: false
+IsConfirmationEmailSent: false
+Devspaces:
+  IsEnabled: false
+  IsAdmin: false
+SourceLastRefresh: 0


### PR DESCRIPTION
Adds functionality to remove users from tenants.  Removes tenant arg to prevent CLI confusion on desired tenant.  Adds example user yaml file.
```
~/workspaces/sureswift-parsers/docparser-infrastructure [docparser]: !665
duploctl user add_user_to_tenant nobody@duplocloud.net --tenant testing
"User 'nobody@duplocloud.net' added to tenant 'testing'"
~/workspaces/sureswift-parsers/docparser-infrastructure [docparser]: duploctl user remove_user_from_tenant nobody@duplocloud.net --tenant testing
"User 'nobody@duplocloud.net' removed from tenant 'testing'"
```
