### PR TITLE
update client error handling to print docstrings on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updates
+ - changed client error handling to display docstrings on bad input
+
 ## [0.2.31] - 2024-07-29
 
 ### Added 

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -287,7 +287,7 @@ Available Resources:
     try:
       d = r(*args)
     except TypeError:
-      if(r.__doc__): 
+      if (r.__doc__):
         raise DuploError(r.__doc__, 400)
       else: 
         traceback.print_exc()

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -7,6 +7,7 @@ import yaml
 import json
 import jsonpatch
 import logging
+import traceback
 from datetime import datetime, timezone, timedelta
 from urllib.parse import urlparse
 from cachetools import cachedmethod, TTLCache
@@ -283,7 +284,15 @@ Available Resources:
     if not resource:
       raise DuploError(str(self), 400)
     r = self.load(resource)
-    d = r(*args)
+    try:
+      d = r(*args)
+    except TypeError:
+      if(r.__doc__): 
+        raise DuploError(r.__doc__, 400)
+      else: 
+        traceback.print_exc()
+        raise DuploError(f"No docstring found, error calling command {resource} : Traceback printed", 400)
+
     if d is None:
       return None
     d = self.filter(d)


### PR DESCRIPTION
### **User description**
small change to client __call__ to avoid raw TypeErrors and such


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Enhanced error handling in the `__call__` method of the client to provide more informative error messages.
- Added a try-except block to catch `TypeError` and print the resource's docstring if available.
- Included traceback printing for cases where no docstring is found.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Improve client error handling with detailed messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplocloud/client.py

<li>Added <code>traceback</code> import.<br> <li> Wrapped resource call in try-except block.<br> <li> Enhanced error handling to print docstrings on <code>TypeError</code>.<br> <li> Added fallback error message with traceback printing.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/91/files#diff-ed921a2441e8df6f226f7024b875dea79afcd0d87e1326c37b19d232dba3f740">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

