### PR TITLE
Duplo 20526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - added tenant DNS config command to retrieve configuration
+- added functionality to search for users by tenant
+- moved command to add/remove users from tenant from user to tenant
 
 ## [0.2.32] - 2024-08-05
 

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -40,7 +40,7 @@ class DuploTenant(DuploResource):
   @Command()
   def list_users(self, 
                name: args.NAME) -> dict:
-    """List users assigned to a tenants
+    """List users assigned to a tenant
     
     Retrieve a list of all users with access to a tenant
 

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -36,6 +36,47 @@ class DuploTenant(DuploResource):
     """
     response = self.duplo.get("adminproxy/GetTenantNames")
     return response.json()
+  
+  @Command()
+  def list_users(self, 
+               name: args.NAME) -> dict:
+    """List users assigned to a tenants
+    
+    Retrieve a list of all users with access to a tenant
+
+    Usage: Basic CLI Use
+      ```bash
+      duploctl tenant list_users
+      ```
+    
+    Returns:
+      tenants (list): A list of tenants.
+    """
+    tenant = self.find(name)
+    tenant_id = tenant["TenantId"]
+    response = self.duplo.get("admin/GetAllTenantAuthInfo")
+    tenant_users = {}
+    for tenant in response.json():
+      if tenant["TenantId"] == tenant_id:
+        for user in tenant['UserAccess']:
+             tenant_users[user['Username']] = {
+                "IsReadOnly": user['Policy']['IsReadOnly'],
+                "IsAdmin": "false"
+             }
+    # Admins have access to all tenants.  Check for them and add them
+    users = self.duplo.get("admin/GetAllUserRoles")
+    for user in users.json():
+      if "Administrator" in user['Roles']:
+        # If the user is already in the list for the tenant, mark them as admins. I don't think this can actually happen.
+        if user['Username'] in tenant_users:
+          tenant_users[user['Username']]["IsAdmin"] = "true"
+        # Add the admin to the list of users with access. Admins are always readonly: false.
+        else:
+          tenant_users[user['Username']] = {
+                  "IsReadOnly": "false",
+                  "IsAdmin": "true"
+                }
+    return tenant_users
 
   @Command()
   def find(self, 
@@ -545,3 +586,64 @@ class DuploTenant(DuploResource):
     tenant_id = tenant["TenantId"]
     response = self.duplo.get(f"v3/subscriptions/{tenant_id}/aws/dnsConfig")
     return response.json()
+
+  @Command()
+  def add_user(self, 
+    name: args.NAME) -> dict:
+    """Add User to Tenant
+    
+    Usage: CLI Usage
+      ```sh
+      duploctl tenant add_user <user> --tenant <tenant_name>
+      ```
+
+    Args:
+      name: The name of the user to add to the tenant.
+      tenant: The name of the tenant to add the user to.
+
+    Returns:
+      message: A message indicating the user was added to the tenant.
+    """
+    tenant_id = self.find(self.duplo.tenant)["TenantId"]
+    res = self.duplo.post("admin/UpdateUserAccess", {
+      "Policy": { "IsReadOnly": None },
+      "Username": name,
+      "TenantId": tenant_id
+    })
+    # check http response is 204
+    if res.status_code != 204:
+      raise DuploError(f"Failed to add user '{name}' to tenant '{self.duplo.tenant}'", res["status_code"])
+    else:
+      return f"User '{name}' added to tenant '{self.duplo.tenant}'"
+    
+  @Command()
+  def remove_user(self, 
+                 name: args.NAME) -> dict:
+    """Remove a User from a Tenant
+    
+    Usage: CLI Usage
+      ```sh
+      duploctl tenant remove_user <user> --tenant <tenant_name>
+      ```
+
+    Args:
+      name: The name of the user to remove from the tenant.
+      tenant: The name of the tenant to remove the user from.
+
+    Returns:
+      message: A message indicating the user was removed from the tenant.
+    """
+    tenant_id = self.find(self.duplo.tenant)["TenantId"]
+    res = self.duplo.post("admin/UpdateUserAccess", {
+      "Policy": {},
+      "Username": name,
+      "TenantId": tenant_id,
+      "State": "deleted"
+    })
+
+    # check http response is 204
+    if res.status_code != 204:
+      raise DuploError(f"Failed to remove user '{name}' from tenant '{self.duplo.tenant}'", res["status_code"])
+    else:
+      return f"User '{name}' removed from tenant '{self.duplo.tenant}'"
+    

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -26,66 +26,6 @@ class DuploUser(DuploResource):
       raise DuploError(f"User '{name}' not found", 404)
   
   @Command()
-  def add_user_to_tenant(self, 
-                 name: args.NAME) -> dict:
-    """Add User to Tenant
-    
-    Usage: CLI Usage
-      ```sh
-      duploctl user add_user_to_tenant <user> --tenant <tenant_name>
-      ```
-
-    Args:
-      name: The name of the user to add to the tenant.
-      tenant: The name of the tenant to add the user to.
-
-    Returns:
-      message: A message indicating the user was added to the tenant.
-    """
-    tenant_id = self.tenent_svc.find(self.duplo.tenant)["TenantId"]
-    res = self.duplo.post("admin/UpdateUserAccess", {
-      "Policy": { "IsReadOnly": None },
-      "Username": name,
-      "TenantId": tenant_id
-    })
-    # check http response is 204
-    if res.status_code != 204:
-      raise DuploError(f"Failed to add user '{name}' to tenant '{self.duplo.tenant}'", res["status_code"])
-    else:
-      return f"User '{name}' added to tenant '{self.duplo.tenant}'"
-    
-  @Command()
-  def remove_user_from_tenant(self, 
-                 name: args.NAME) -> dict:
-    """Remove a User from a Tenant
-    
-    Usage: CLI Usage
-      ```sh
-      duploctl user remove_user_from_tenant <user> --tenant <tenant_name>
-      ```
-
-    Args:
-      name: The name of the user to remove from the tenant.
-      tenant: The name of the tenant to remove the user from.
-
-    Returns:
-      message: A message indicating the user was removed from the tenant.
-    """
-    tenant_id = self.tenent_svc.find(self.duplo.tenant)["TenantId"]
-    res = self.duplo.post("admin/UpdateUserAccess", {
-      "Policy": {},
-      "Username": name,
-      "TenantId": tenant_id,
-      "State": "deleted"
-    })
-
-    # check http response is 204
-    if res.status_code != 204:
-      raise DuploError(f"Failed to remove user '{name}' from tenant '{self.duplo.tenant}'", res["status_code"])
-    else:
-      return f"User '{name}' removed from tenant '{self.duplo.tenant}'"
-    
-  @Command()
   def create(self, 
              body: args.BODY):
     """Create a new user.


### PR DESCRIPTION
Moves add/remove user from tenant
adds command to list users by tenant

```
(.venv) ~/workspaces/duplocloud/duploctl [salesdemo]: duploctl tenant list_users --tenant dev01  | jq .
[
  {
    "Username": "test",
    "IsReadOnly": "True",
    "IsAdmin": "False"
  },
  {
    "Username": "aaron@duplocloud.net",
    "IsReadOnly": "False",
    "IsAdmin": "True"
  }
]
```

```
(.venv) ~/workspaces/duplocloud/duploctl [salesdemo]: duploctl tenant add_user test --tenant compliance
"User 'test' added to tenant 'compliance'"

 ~/workspaces/duplocloud/duploctl [salesdemo]: duploctl tenant list_users --tenant compliance | jq .
[
  {
    "Username": "test",
    "IsReadOnly": "False",
    "IsAdmin": "False"
  },
  {
    "Username": "aaron@duplocloud.net",
    "IsReadOnly": "False",
    "IsAdmin": "True"
  }
]
```

```
(.venv) ~/workspaces/duplocloud/duploctl [salesdemo]: duploctl tenant remove_user test --tenant compliance
"User 'test' removed from tenant 'compliance'"

(.venv) ~/workspaces/duplocloud/duploctl [salesdemo]: duploctl tenant list_users --tenant compliance | jq .
[
  {
    "Username": "aaron@duplocloud.net",
    "IsReadOnly": "False",
    "IsAdmin": "True"
  }
]
```
