### PR TITLE
configmaps and secrets from files and literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Include generated Github release notes in the release description
  - Install instructions in the docs
  - Cleaned up pipeline and added test reporting into the PRs
+ - Configmaps and secrets can be created with data values `--from-file` and `--from-literal`. The result can be displayed with `--dry-run`. Both are a key=value pair but files can simply default the key to the filename.
 
 ### Fixed 
 
  - Fixed update_pod_label subcommand functionality for service.
  - fixed many little issues with the docs like misspelled args, unneeded extra ones, and even missing types
+ - discovered why Args were not renaming based on the function arg.
 
 ## [0.2.33] - 2024-08-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,3 +48,5 @@ RUN pip install --no-cache-dir ./dist/*.whl && \
 
 # Set the entrypoint command for the container
 ENTRYPOINT ["duploctl"]
+
+CMD [ "version" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,20 +2,19 @@ services:
 
   duploctl: &base
     image: &image duplocloud/duploctl:latest
-    build: &build
+    build: 
       target: runner
-      args:
+      args: &args
         PY_VERSION: ${PY_VERSION:-3.12}
       tags:
       - *image
       - duplocloud/duploctl:${GIT_SHA:-latest}
       - duplocloud/duploctl:${GIT_REF:-latest}
       - duplocloud/duploctl:${GIT_TAG:-latest}
-      platforms: &platforms
-      - linux/amd64
-      - linux/arm64
-      x-bake: &bake
-        platforms: *platforms
+      x-bake: 
+        platforms: &platforms
+        - linux/amd64
+        - linux/arm64
         cache-to: type=gha,scope=runner,mode=max
         cache-from: type=gha,scope=runner
     container_name: duploctl
@@ -23,37 +22,17 @@ services:
       DUPLO_HOST: ${DUPLO_HOST:-}
       DUPLO_TOKEN: ${DUPLO_TOKEN:-}
       DUPLO_TENANT: ${DUPLO_TENANT:-}
-    # command:
-    # - version
+      DUPLO_OUTPUT: yaml
 
   duploctl-bin:
     <<: *base
     container_name: duploctl-bin
-    image: &binImage duplocloud/duploctl:bin
+    image: duplocloud/duploctl:bin
     build:
-      <<: *build
       target: bin
-      tags:
-      - *binImage
+      args: *args
       x-bake:
-        <<: *bake
+        platforms: *platforms
         output: type=local,dest=./dist
         cache-to: type=gha,scope=installer,mode=max
         cache-from: type=gha,scope=installer
-
-  duploctl-dev:
-    image: duplocloud/duploctl:dev
-    build:
-      target: dev
-    volumes:
-    # Update this to wherever you want VS Code to mount the folder of your project
-    - .:/workspaces:cached
-
-    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
-    # cap_add:
-    #   - SYS_PTRACE
-    # security_opt:
-    #   - seccomp:unconfined
-
-    # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,4 +2,12 @@
 
 mkdir -p config dist dist/docs
 
-pip install --editable .[build,test,aws,docs]
+pip install --editable '.[build,test,aws,docs]'
+
+# for each folder in the plugins directory
+for plugin in plugins/*; do
+  # install only if the folder is a directory and a pyproject.toml file exists
+  if [ -d "$plugin" ] && [ -f "$plugin/pyproject.toml" ]; then
+    pip install --editable "$plugin"
+  fi
+done

--- a/src/duplo_resource/configmap.py
+++ b/src/duplo_resource/configmap.py
@@ -1,10 +1,69 @@
 from duplocloud.client import DuploClient
+from duplocloud.errors import DuploError
 from duplocloud.resource import DuploTenantResourceV3
-from duplocloud.commander import Resource
+from duplocloud.commander import Command, Resource
+import duplocloud.args as args
 
 @Resource("configmap")
 class DuploConfigMap(DuploTenantResourceV3):
   
   def __init__(self, duplo: DuploClient):
     super().__init__(duplo, "k8s/configmap")
+
+  @Command()
+  def create(self, 
+             name: args.NAME=None,
+             body: args.BODY=None,
+             data: args.DATAMAP=None,
+             dryrun: args.DRYRUN=False,
+             wait: args.WAIT=False) -> dict:
+    """Create a Configmap resource.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl configmap create -f 'configmap.yaml'
+      ```
+      Contents of the `configmap.yaml` file
+      ```yaml
+      --8<-- "src/tests/data/configmap.yaml"
+      ```
+
+    Example: One liner example
+      ```sh
+      echo \"\"\"
+      --8<-- "src/tests/data/configmap.yaml"
+      \"\"\" | duploctl configmap create -f -
+      ```
+    
+    Args:
+      name: The name to set the configmap to.
+      body: The resource to create.
+      data: The data to add to the configmap.
+      dryrun: Do not submit any changes to the server.
+      wait: Wait for the resource to be created.
+
+    Returns: 
+      message: Success message.
+
+    Raises:
+      DuploError: If the resource could not be created.
+    """
+    if not name and not body:
+      raise DuploError("Name is required when body is not provided")
+    if not body:
+      body = {}
+    # make sure the body has a metadata key
+    if 'metadata' not in body:
+      body['metadata'] = {}
+    # also make sure the data key is present
+    if 'data' not in body:
+      body['data'] = {}
+    if name:
+      body['metadata']['name'] = name
+    if data:
+      body['data'].update(data)
+    if dryrun:
+      return body
+    else:
+      return super().create(body, wait=wait)
 

--- a/src/duplo_resource/secret.py
+++ b/src/duplo_resource/secret.py
@@ -1,6 +1,8 @@
+from duplocloud import args
 from duplocloud.client import DuploClient
+from duplocloud.errors import DuploError
 from duplocloud.resource import DuploTenantResourceV3
-from duplocloud.commander import Resource
+from duplocloud.commander import Command, Resource
 
 @Resource("secret")
 class DuploSecret(DuploTenantResourceV3):
@@ -10,3 +12,27 @@ class DuploSecret(DuploTenantResourceV3):
 
   def name_from_body(self, body):
     return body["SecretName"]
+  
+  @Command()
+  def create(self, 
+             name: args.NAME=None,
+             body: args.BODY=None,
+             data: args.DATAMAP=None,
+             dryrun: args.DRYRUN=False,
+             wait: args.WAIT=False) -> dict:
+    """Create a Secret"""
+    if not name and not body:
+      raise DuploError("Name is required when body is not provided")
+    if not body:
+      body = {}
+    # also make sure the data key is present
+    if 'SecretData' not in body:
+      body['SecretData'] = {}
+    if name:
+      body['SecretName'] = name
+    if data:
+      body['SecretData'].update(data)
+    if dryrun:
+      return body
+    else:
+      return super().create(body, wait=wait)

--- a/src/duplocloud/args.py
+++ b/src/duplocloud/args.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from .argtype import Arg, YamlAction, JsonPatchAction
+from .argtype import Arg, YamlAction, JsonPatchAction, DataMapAction
 from .commander import available_resources, available_formats, VERSION
 
 # the global args for the CLI
@@ -72,6 +72,19 @@ BODY = Arg("file", "-f", "--cli-input",
             help='A file to read the input from',
             type=argparse.FileType('r'),
             action=YamlAction)
+"""File Body  
+
+This is the file path to a file with the specified resources body within. Each Resource will have it's own schema for the body. This is a yaml/json file that will be parsed and used as the body of the request. View the docs for each individual resource to see the schema for the body.
+"""
+
+DATAMAP = Arg("fromfile","--from-file", "--from-literal",
+            help='A file or literal value to add to the data map',
+            action=DataMapAction)
+
+DRYRUN = Arg("dryrun", "--dry-run",
+            help='Do not submit any changes to the server',
+            type=bool,
+            action='store_true')
 
 ARN = Arg("aws-arn", "--arn",
            help='The aws arn',

--- a/src/tests/files/password.txt
+++ b/src/tests/files/password.txt
@@ -1,0 +1,1 @@
+verysecretpassword

--- a/src/tests/test_commander.py
+++ b/src/tests/test_commander.py
@@ -1,11 +1,14 @@
+import pathlib
 import pytest 
 # import unittest
 import argparse
 from duplocloud.commander import schema, resources, Command, get_parser, aliased_method, extract_args, available_resources, load_resource
-from duplocloud.argtype import Arg
+from duplocloud.argtype import Arg, DataMapAction
 from duplocloud.errors import DuploError
 # from duplo_resource.service import DuploService
 # from duplocloud.resource import DuploResource
+
+dir = pathlib.Path(__file__).parent.resolve()
 
 NAME = Arg("name", 
             help='A test name arg')
@@ -96,3 +99,22 @@ def test_arg_type():
 def test_aliased_command():
   method = aliased_method(SomeResource, "test")
   assert method == "tester"
+
+@pytest.mark.unit
+def test_datamap_action():
+  fname = "password.txt"
+  password = "verysecretpassword"
+  fpath = f"{dir}/files/{fname}"
+  p = argparse.ArgumentParser()
+  p.add_argument("--from-file", "--from-literal", dest="data", action=DataMapAction)
+  args = [
+    "--from-file", fpath,
+    "--from-file", f"renamed={fpath}",
+    "--from-literal", "foo=bar"
+  ]
+  ns = p.parse_args(args)
+  assert ns.data == {
+    "password.txt": password,
+    "renamed": password,
+    "foo": "bar"
+  }


### PR DESCRIPTION
## Describe Changes

Configmaps and secrets can be created `--from-file` or `--from-literal` just like kubectl does. It even includes the `--dry-run` option. 

## Link to Issues  

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
