### PR TITLE
copy up other docker config

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -42,7 +42,10 @@
 				"ms-python.debugpy",
 				"redhat.vscode-yaml",
 				"charliermarsh.ruff"
-			]
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
+			}
 		}
 	}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed update_pod_label subcommand functionality for service.
  - fixed many little issues with the docs like misspelled args, unneeded extra ones, and even missing types
  - discovered why Args were not renaming based on the function arg.
+ - Fixed issue where a services otherDockerConfig was cleared on updates. 
 
 ## [0.2.33] - 2024-08-12
 

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -78,6 +78,7 @@ class DuploService(DuploTenantResourceV2):
     if ((ttags := body["Template"].get("AllocationTags", None))
         and not body.get("AllocationTags", None)):
       body["AllocationTags"] = ttags
+    body["OtherDockerConfig"] = body["Template"]["OtherDockerConfig"]
     self.duplo.post(self.endpoint("ReplicationControllerChangeAll"), body)
     if wait:
       self.wait(old, body)


### PR DESCRIPTION
### **User description**
## Describe Changes

Fix issue with otherDockerconfig getting erased on updates. 

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-21004

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed an issue where `OtherDockerConfig` was being erased during updates by ensuring it is copied from `Template` to the main body in `service.py`.
- Enhanced the development container configuration by adding a default Python interpreter path in `.devcontainer.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Fix and ensure persistence of `OtherDockerConfig` during updates</code></dd></summary>
<hr>

src/duplo_resource/service.py

<li>Ensure <code>OtherDockerConfig</code> is copied from <code>Template</code> to the main body.<br> <li> Fix issue with <code>OtherDockerConfig</code> being erased on updates.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/101/files#diff-de4bdab4d945f3f4c737be6a44e3c3c11850f302766a911d4bc30229766398ab">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.devcontainer.json</strong><dd><code>Update devcontainer settings with Python interpreter path</code></dd></summary>
<hr>

.devcontainer.json

<li>Add Python interpreter path setting.<br> <li> Enhance development container configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/101/files#diff-8c75d30eaaa096649631dde76e321d13a6849c64137f3f7f777429ef9fd6b9e2">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

