### PR TITLE
DUPLO-25186: Add logic to set IsAnyHostAllowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.36] - 2024-09-24
+### Fixed
 
-### Added
-
-- Added logic to CronJob Update to set `isAnyHostAllowed`
+- Fixed CronJob Update by adding missing logic to set `isAnyHostAllowed`. This is due to a the object returned from the `GET` request being slightly different to the object expected in the `PUT/POST` request.
 
 ## [0.2.35] - 2024-09-20
 
@@ -57,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for tenant start/stop
 
 ### Updates
+
 - changed handling of tenant arg in user resource
 - add reference yaml for users
 - changed client error handling to display docstrings on bad input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,178 +7,185 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.36] - 2024-09-24
+
+### Added
+
+- Added logic to CronJob Update to set `isAnyHostAllowed`
+
 ## [0.2.35] - 2024-09-20
 
 ### Added
 
- - Include generated Github release notes in the release description
- - Install instructions in the docs
- - Cleaned up pipeline and added test reporting into the PRs
- - Configmaps and secrets can be created with data values `--from-file` and `--from-literal`. The result can be displayed with `--dry-run`. Both are a key=value pair but files can simply default the key to the filename.
-
-### Fixed 
-
- - Fixed update_pod_label subcommand functionality for service.
- - fixed many little issues with the docs like misspelled args, unneeded extra ones, and even missing types
- - discovered why Args were not renaming based on the function arg.
- - Case insensitive tenant name comparison. 
- - Fixed issue where a services otherDockerConfig was cleared on updates. 
- - Fixed issue where ecs update image was removing secrets,commands and env variables
- 
-## [0.2.33] - 2024-08-12
-
-### Added 
- 
- - Added an apply method on base classes. Now most resources can simply `apply` files. 
- - added tenant DNS config command to retrieve configuration
- - added functionality to search for users by tenant
- - moved command to add/remove users from tenant from user to tenant
- - Added new function in service for updating pod label config.
-
-### Updates  
-
- - performance improvements to load cli args only when needed
- - The `command` method on all `DuploResources` returns a factory function with a parser already scoped into the functions argument annotations. 
- - Custom display in the docs for CLI Arguments
- - Added docs for internals of the CLI for anyone wanting to contribute or extend. 
- - Comply with Github best practices, ie added Security, Code of conduct, License, issue/pr templates, etc. [Community Standards](https://github.com/duplocloud/duploctl/community)
-
-## [0.2.32] - 2024-08-05
-
-### Added 
-
- - remove_user_from_tenant command
- - Added support for tenant start/stop
-
-### Updates 
- - changed handling of tenant arg in user resource
- - add reference yaml for users
- - changed client error handling to display docstrings on bad input
-
-
-## [0.2.31] - 2024-07-29
-
-### Added 
-
- - cloudfront resource with crud operations
- - a new plan resource to view
- - print token command when you just want the token
-
-### Updates 
- - updated all of the resources to show up in the docs
- - arm64 linux binary is now available in the homebrew formula
- - auto generate markdown templates for resources when building the docs
- - updated docs for services.update_env to include usage
-
-## [0.2.30] - 2024-07-11
-
-### Added 
-
- - New aws plugin which can
-   - generate boto3 clients using JIT
-   - `update_website` command to push new code to an S3 bucket and invalidate the cloudfront cache
- - Tenant resource has a new `region` command to get just the current region for the tenant.
- - generating an aws profile without a name will default to "duplo"
- - publish linux/arm64 standalone binary
-
-## [0.2.29] - 2024-06-07
-
-### Added 
-
- - publish docs on main branch push
-
-### Fixed 
-
- - Better error handling for the version command. It failed when the server didn't have the version endpoint.
-
-## [0.2.28] - 2024-06-04
-### Added 
-
- - Support for Storage Class
- - Support for PVC
- - Added support for create and delete user
- - start, stop, restart for hosts with `--wait`
- - Allow code to programmatically return the config from `update_kubeconfig` when save is false.
- - more docs for the wiki
- - A new check to make sure CHANGELOG.md is updated before merging a PR. 
- - version command now shows server version
+- Include generated Github release notes in the release description
+- Install instructions in the docs
+- Cleaned up pipeline and added test reporting into the PRs
+- Configmaps and secrets can be created with data values `--from-file` and `--from-literal`. The result can be displayed with `--dry-run`. Both are a key=value pair but files can simply default the key to the filename.
 
 ### Fixed
 
-  - Kubernetes commands with JIT were not getting the CA when using GCP. 
+- Fixed update_pod_label subcommand functionality for service.
+- fixed many little issues with the docs like misspelled args, unneeded extra ones, and even missing types
+- discovered why Args were not renaming based on the function arg.
+- Case insensitive tenant name comparison.
+- Fixed issue where a services otherDockerConfig was cleared on updates.
+- Fixed issue where ecs update image was removing secrets,commands and env variables
+
+## [0.2.33] - 2024-08-12
+
+### Added
+
+- Added an apply method on base classes. Now most resources can simply `apply` files.
+- added tenant DNS config command to retrieve configuration
+- added functionality to search for users by tenant
+- moved command to add/remove users from tenant from user to tenant
+- Added new function in service for updating pod label config.
+
+### Updates
+
+- performance improvements to load cli args only when needed
+- The `command` method on all `DuploResources` returns a factory function with a parser already scoped into the functions argument annotations.
+- Custom display in the docs for CLI Arguments
+- Added docs for internals of the CLI for anyone wanting to contribute or extend.
+- Comply with Github best practices, ie added Security, Code of conduct, License, issue/pr templates, etc. [Community Standards](https://github.com/duplocloud/duploctl/community)
+
+## [0.2.32] - 2024-08-05
+
+### Added
+
+- remove_user_from_tenant command
+- Added support for tenant start/stop
+
+### Updates
+- changed handling of tenant arg in user resource
+- add reference yaml for users
+- changed client error handling to display docstrings on bad input
+
+## [0.2.31] - 2024-07-29
+
+### Added
+
+- cloudfront resource with crud operations
+- a new plan resource to view
+- print token command when you just want the token
+
+### Updates
+
+- updated all of the resources to show up in the docs
+- arm64 linux binary is now available in the homebrew formula
+- auto generate markdown templates for resources when building the docs
+- updated docs for services.update_env to include usage
+
+## [0.2.30] - 2024-07-11
+
+### Added
+
+- New aws plugin which can
+  - generate boto3 clients using JIT
+  - `update_website` command to push new code to an S3 bucket and invalidate the cloudfront cache
+- Tenant resource has a new `region` command to get just the current region for the tenant.
+- generating an aws profile without a name will default to "duplo"
+- publish linux/arm64 standalone binary
+
+## [0.2.29] - 2024-06-07
+
+### Added
+
+- publish docs on main branch push
+
+### Fixed
+
+- Better error handling for the version command. It failed when the server didn't have the version endpoint.
+
+## [0.2.28] - 2024-06-04
+
+### Added
+
+- Support for Storage Class
+- Support for PVC
+- Added support for create and delete user
+- start, stop, restart for hosts with `--wait`
+- Allow code to programmatically return the config from `update_kubeconfig` when save is false.
+- more docs for the wiki
+- A new check to make sure CHANGELOG.md is updated before merging a PR.
+- version command now shows server version
+
+### Fixed
+
+- Kubernetes commands with JIT were not getting the CA when using GCP.
 
 ## [0.2.27] - 2024-04-22
 
-### Fixed 
+### Fixed
 
- - homebrew deployment uses pip freeze for it's dependencies so all subpackages exist as well
+- homebrew deployment uses pip freeze for it's dependencies so all subpackages exist as well
 
 ## [0.2.26] - 2024-04-17
 
-### Added 
+### Added
 
- - Support for `DUPLO_TENANT_ID` or `--tenant-id` as a global argument alternative to using the tenant name
- - `WARN` is default log level and `--wait` will show more logs when set to `DEBUG`
- - Support for AWS S3
- - Github Pages Site for documentation using mkdocs
+- Support for `DUPLO_TENANT_ID` or `--tenant-id` as a global argument alternative to using the tenant name
+- `WARN` is default log level and `--wait` will show more logs when set to `DEBUG`
+- Support for AWS S3
+- Github Pages Site for documentation using mkdocs
 
-### Fixed 
+### Fixed
 
- - `--wait` flag for azures updates
+- `--wait` flag for azures updates
 
 ## [0.2.25] - 2024-04-15
 
 ### Added
 
- - all actions use the duploctl[bot] app for commits
+- all actions use the duploctl[bot] app for commits
 
 ## [0.2.23] - 2024-04-14
 
 ### Fixed
 
- - jit timout is now 1 hr vs 6
- - pipeline commits using duploctl[bot] app instead of default token
- - full changelog bump and push working now with the duploctl[bot]
+- jit timout is now 1 hr vs 6
+- pipeline commits using duploctl[bot] app instead of default token
+- full changelog bump and push working now with the duploctl[bot]
 
 ## [0.2.18] - 2024-04-11
 
 ### Added
 
- - A version bump script which includes changelog notes in GHA releases
- - shared setup action in piplines
+- A version bump script which includes changelog notes in GHA releases
+- shared setup action in piplines
 
 ### Fixed
 
- - azure services had an issue with the `--wait`
- - homebrew installation needs the `jsonpointer` library explicit in pyproject
- - broken pipeline for docker from updated action
- - simplifed the cleanup script for integration tests
+- azure services had an issue with the `--wait`
+- homebrew installation needs the `jsonpointer` library explicit in pyproject
+- broken pipeline for docker from updated action
+- simplifed the cleanup script for integration tests
 
 ## [0.2.16] - 2024-04-10
 
-### Added 
+### Added
 
- - Actual JIT expiration dates sent to kubectl and aws cli
- - CRUD for services and rds
- - jsonpatch args for updating services
- - `--wait` enabled on all updates to a service including `update_image`
- - better logging for wait operations
- - introduced v2 and v3 base resource classes
- - pod resource with get, list, and show logs
- - ingress resource with all crud operations
- - create and watch jobs with logs returned
- - rds resource with all crud operations and individual actions present in the ui
- - fully working integration tests with proper waiting
- - creating a host without an image will pick a sane default
- - display available host AMIs for a tenant
+- Actual JIT expiration dates sent to kubectl and aws cli
+- CRUD for services and rds
+- jsonpatch args for updating services
+- `--wait` enabled on all updates to a service including `update_image`
+- better logging for wait operations
+- introduced v2 and v3 base resource classes
+- pod resource with get, list, and show logs
+- ingress resource with all crud operations
+- create and watch jobs with logs returned
+- rds resource with all crud operations and individual actions present in the ui
+- fully working integration tests with proper waiting
+- creating a host without an image will pick a sane default
+- display available host AMIs for a tenant
 
 ## [v0.2.15] - 2024-03-22
 
 ### Added
 
- - `--admin` flag for jit commands
- - tenant level jit commands
+- `--admin` flag for jit commands
+- tenant level jit commands
 
 ### Changed
 
- - jit commands are no longer admin by default, tenant level is now default
+- jit commands are no longer admin by default, tenant level is now default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,18 @@
 # Contributing
 
-Follow these steps to be proper. There is a lot of very specific steps and automations, please read this entire document before starting. Many questions will be answered by simply getting everything setup exactly the same way in the instructions. 
+Follow these steps to be proper. There is a lot of very specific steps and automations, please read this entire document before starting. Many questions will be answered by simply getting everything setup exactly the same way in the instructions.
 
 ## Clone the Repo
 
-Clone the repo with the wiki submodule. The wiki submodule contains the static content and templates for mkdocs. 
+Clone the repo with the wiki submodule. The wiki submodule contains the static content and templates for mkdocs.
+
 ```sh
 git clone --recurse-submodules git@github.com:duplocloud/duploctl.git
 ```
 
-## Direnv Setup  
+## Direnv Setup
 
-Here is a good start for a decent `.envrc` file.  
+Here is a good start for a decent `.envrc` file.
 
 ```sh
 source_up .envrc # only when this is under a parent workspace containing a .envrc file
@@ -27,7 +28,7 @@ export DUPLO_CONFIG="${DUPLO_HOME}/duploconfig.yaml"
 export DUPLO_CACHE="${DUPLO_HOME}/cache"
 ```
 
-## Installation    
+## Installation
 
 Install dependencies in editable mode so you can use step through debugging. All of the optional dependencies are included within the square brackets. You can see what they all are in the [`pyproject.toml`](pyproject.toml) file.
 
@@ -35,39 +36,39 @@ Install dependencies in editable mode so you can use step through debugging. All
 pip install --editable '.[build,test,aws,docs]'
 ```
 
-## Changelog  
+## Changelog
 
 Make sure to take note of your changes in the changelog. This is done by updating the `CHANGELOG.md` file. Add any new details under the `## [Unreleased]` section. When a new version is published, the word `Unreleased` will be replaced with the version number and the date. The section will also be the detailed release notes under releases in Github. The checks on the PR will fail if you don't add any notes in the changelog.
 
-See the [`version.py`](./scripts/version.py) script for more details on how the version command will inject the new version into the changelog by resetting the `Unreleased` section. 
+See the [`version.py`](./scripts/version.py) script for more details on how the version command will inject the new version into the changelog by resetting the `Unreleased` section.
 
-## Signed Commits  
+## Signed Commits
 
-This is a public repo, one cannot simply trust that a commit came from who it says it did. To ensure the integrity of the commits, all commits must be signed. Your commits and PR will be rejected if they are not signed. Please read more about how to do this here if you do not know how: [Github Signing Commits](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/signing-commits). Ideally, if you have 1password, please follow these instructions: [1Password Signing Commits](https://blog.1password.com/git-commit-signing/).  
+This is a public repo, one cannot simply trust that a commit came from who it says it did. To ensure the integrity of the commits, all commits must be signed. Your commits and PR will be rejected if they are not signed. Please read more about how to do this here if you do not know how: [Github Signing Commits](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/signing-commits). Ideally, if you have 1password, please follow these instructions: [1Password Signing Commits](https://blog.1password.com/git-commit-signing/).
 
-## Building Artifacts  
+## Building Artifacts
 
-Build the pip package. This will cache in the build folder and the final output will be in the dist folder. This package is deployed to [pypi](https://pypi.org/project/duplocloud-client/).  
+Build the pip package. This will cache in the build folder and the final output will be in the dist folder. This package is deployed to [pypi](https://pypi.org/project/duplocloud-client/).
 ```sh
 python -m build
 ```
 
-Building a plugin. These plugins don't necessarily need to be on pypi. They are just included alongside the release in Github. The example below shows how to build the AWS plugin. Simply replace `aws` with whatever folder name is in the [`plugins`](./plugins/) directory.  
+Building a plugin. These plugins don't necessarily need to be on pypi. They are just included alongside the release in Github. The example below shows how to build the AWS plugin. Simply replace `aws` with whatever folder name is in the [`plugins`](./plugins/) directory.
 ```sh
 python -m build plugins/aws/ -o=dist
 ```
 
-Create a single binary build for the cli using pyinstaller. These are ultimately included in the Github release so Homebrew can use them. Check out the [`scripts/installer.spec`](./scripts/installer.spec) file for the pyinstaller configuration and the [`installer.yml`](./.github/workflows/installer.yml) workflow for more details.  
+Create a single binary build for the cli using pyinstaller. These are ultimately included in the Github release so Homebrew can use them. Check out the [`scripts/installer.spec`](./scripts/installer.spec) file for the pyinstaller configuration and the [`installer.yml`](./.github/workflows/installer.yml) workflow for more details.
 ```sh
 ./scripts/installer.spec
 ```
 
-Build the Homebrew formula from a tagged release. Normally only the pipeline will run this script which does properly choose the right git tag before running. This ensures the pip dependencies are correct when building the formula.  
+Build the Homebrew formula from a tagged release. Normally only the pipeline will run this script which does properly choose the right git tag before running. This ensures the pip dependencies are correct when building the formula.
 ```sh
 ./scripts/formula.py v0.2.15
 ```
 
-## Version Bump  
+## Version Bump
 
 Get the current version:
 
@@ -79,13 +80,13 @@ When building the artifact the setuptools scm tool will use the a snazzy semver 
 
 _ref:_ [SetupTools SCM](https://pypi.org/project/setuptools-scm/)
 
-When Ready to publish a new version live, go to the [publish.yml](https://github.com/duplocloud/duploctl/actions/workflows/publish.yml) workflow and run the workflow manually. This will bump the version, build the artifact, and push the new version to pypi. 
+When Ready to publish a new version live, go to the [publish.yml](https://github.com/duplocloud/duploctl/actions/workflows/publish.yml) workflow and run the workflow manually. This will bump the version, build the artifact, and push the new version to pypi.
 
-## Docker Image  
+## Docker Image
 
-The docker file uses a couple of stages to do a few different tasks. Mainly the official image is the runner target. The bin target is for generating multiarch binaries. 
+The docker file uses a couple of stages to do a few different tasks. Mainly the official image is the runner target. The bin target is for generating multiarch binaries.
 
-Build the main image locally for your machine using compose.  
+Build the main image locally for your machine using compose.
 ```sh
 docker compose build duploctl
 ```
@@ -94,31 +95,31 @@ Or use bake to for a multiarch image. You just can't export images that are not 
 docker buildx bake duploctl
 ```
 
-Use buildx to build the multiarch binaries. This will output the binaries to the `dist` folder. See the Pyinstaller section above for more details on building the binaries. This runs the Pyinstaller script inside the docker container and outputs the built binaries to the local directory. This only works for linux binaries, Windows is a big maybe.  
+Use buildx to build the multiarch binaries. This will output the binaries to the `dist` folder. See the Pyinstaller section above for more details on building the binaries. This runs the Pyinstaller script inside the docker container and outputs the built binaries to the local directory. This only works for linux binaries, Windows is a big maybe.
 ```sh
 docker buildx bake duploctl-bin
 ```
 
-## Building the Homebrew Formula  
+## Building the Homebrew Formula
 
-The homebrew formula is built from the `scripts/formula.py` script. This script will use the current git tag to build the formula. 
+The homebrew formula is built from the `scripts/formula.py` script. This script will use the current git tag to build the formula.
 
 First you need to get the frozen requirements for the formula. This is done by running the following command. This will do all local dependencies including dev only dependencies. The pipeline will make sure to only include the necessary dependencies.
 ```sh
 pip freeze --exclude-editable > requirements.txt
 ```
-Then generate the formula using the current git tag. 
+Then generate the formula using the current git tag.
 ```sh
 ./scripts/formula.py
 ```
 
-See the [`homebrew.yml`](./.github/workflows/homebrew.yml) workflow for more details on how the formula is built and pushed to the homebrew tap.  
+See the [`homebrew.yml`](./.github/workflows/homebrew.yml) workflow for more details on how the formula is built and pushed to the homebrew tap.
 
-## Documentation 
+## Documentation
 
 The wiki is a static generated website using mkdocs. All of the resource docs are pulled out from the pydoc strings in the code. The convention for docs in code is [Google style docstrings](https://google.github.io/styleguide/pyguide.html).
 
-Here is an example of the docstring format. 
+Here is an example of the docstring format.
 
 ```python
 def my_function(param1, param2) -> dict:
@@ -142,7 +143,7 @@ def my_function(param1, param2) -> dict:
     return {}
 ```
 
-To work on the wiki you need to install the dependencies. You probably already did this if you ran the editable install command above, this includes the optional doc dependencies. 
+To work on the wiki you need to install the dependencies. You probably already did this if you ran the editable install command above, this includes the optional doc dependencies.
 
 ```sh
 pip install --editable '.[docs]'
@@ -154,64 +155,64 @@ To serve the wiki locally you can run the following command. This will start a l
 mkdocs serve
 ```
 
-### Extending MKDocs  
+### Extending MKDocs
 
-All of the customizations done to the doc website are done through the [`mkdocs.py`](scripts/mkdocs.py) file. One ofthe main features, there is a two phases to mkdocs now, phase 1 stages a bunch of generated  and copied markdown files, stage two generates the actual html. 
+All of the customizations done to the doc website are done through the [`mkdocs.py`](scripts/mkdocs.py) file. One ofthe main features, there is a two phases to mkdocs now, phase 1 stages a bunch of generated  and copied markdown files, stage two generates the actual html.
 
 *Static Files:*
 All non generated and very static files go into the [`wiki`](./wiki/) submodule which is cloned into the `./wiki` folder when you clone the repo. The `hooks.py` has a hook that copies the files from the `wiki` folder into the `dist/docs` folder before final compilation.
 
-*Themes:*  
-To extend the mkdocstring python theme, you can copy any of the base templates into `wiki/templates` from here https://github.com/mkdocstrings/python/tree/master/src/mkdocstrings_handlers/python/templates/material. Then simply modify the base template to do what you want. 
+*Themes:*
+To extend the mkdocstring python theme, you can copy any of the base templates into `wiki/templates` from here https://github.com/mkdocstrings/python/tree/master/src/mkdocstrings_handlers/python/templates/material. Then simply modify the base template to do what you want.
 
-## VSCode Setup  
+## VSCode Setup
 
 To be helpful as possible, all of the sweet spot configurations for VSCode are included in the `.vscode` folder. Although these files are committed they have been ignored from the working tree, so feel free to update them as you see fit and they will not be committed.
 
-Here is how git is ignoring the files.  
+Here is how git is ignoring the files.
 
 ```sh
 git update-index --skip-worktree .vscode/settings.json
 ```
 
-### Step Through Debugging  
+### Step Through Debugging
 
-Within the `.vscode/launch.json`, change the `args` to the command you want to debug, this is equivelent to running from the command line. Remember to install the project with `--editable` so you can step through the code easily. 
+Within the `.vscode/launch.json`, change the `args` to the command you want to debug, this is equivelent to running from the command line. Remember to install the project with `--editable` so you can step through the code easily.
 
-### Tasks  
+### Tasks
 
-All of the commands described above have been implemented as VSCode tasks in the `.vscode/tasks.json`. This goes well with the [spmeesseman.vscode-taskexplorer](https://marketplace.visualstudio.com/items?itemName=spmeesseman.vscode-taskexplorer) extension which gives you a nice little button to run the tasks.  
+All of the commands described above have been implemented as VSCode tasks in the `.vscode/tasks.json`. This goes well with the [spmeesseman.vscode-taskexplorer](https://marketplace.visualstudio.com/items?itemName=spmeesseman.vscode-taskexplorer) extension which gives you a nice little button to run the tasks.
 
-### Devcontainer  
+### Devcontainer
 
-The `.devcontainer.json` file is included for quickly spinning up a working enviornment. This is a good way to ensure that all of the dependencies are installed and the correct version of python is being used without fighting with any nuances present in your local environment. 
+The `.devcontainer.json` file is included for quickly spinning up a working enviornment. This is a good way to ensure that all of the dependencies are installed and the correct version of python is being used without fighting with any nuances present in your local environment.
 
-## Self Hosted Mac Arm64 Runner  
+## Self Hosted Mac Arm64 Runner
 
-Due to limitations of GHA, there are no darwin/Arm64 machines to compile the installer for. This means you must install the self hosted runner on your own machine. 
+Due to limitations of GHA, there are no darwin/Arm64 machines to compile the installer for. This means you must install the self hosted runner on your own machine.
 
-First Get a token from here: [GHA New Runner Page](https://github.com/duplocloud/duploctl/settings/actions/runners/new). 
-Set this variable in your `.envrc` file. 
+First Get a token from here: [GHA New Runner Page](https://github.com/duplocloud/duploctl/settings/actions/runners/new).
+Set this variable in your `.envrc` file.
 
 ```sh
 export GH_RUNNER_TOKEN="your-token-here"
 ```
 
-Next you need to run the following command to make a dir and chown it so the setup-python step is happy. 
-[See issue here](https://github.com/actions/setup-python/blob/2f078955e4d0f34cc7a8b0108b2eb7bbe154438e/docs/advanced-usage.md#macos)  
+Next you need to run the following command to make a dir and chown it so the setup-python step is happy.
+[See issue here](https://github.com/actions/setup-python/blob/2f078955e4d0f34cc7a8b0108b2eb7bbe154438e/docs/advanced-usage.md#macos)
 
 ```sh
 sudo mkdir -p /Users/runner /Users/runner/hostedtoolcache
 sudo chown -R "$(id -un)" /Users/runner
 ```
 
-Then run the following command to install the runner and activate it. Simply hit `ctrl+c` to stop the runner when it's not needed.  
+Then run the following command to install the runner and activate it. Simply hit `ctrl+c` to stop the runner when it's not needed.
 
-```sh 
+```sh
 ./scripts/runner_install.sh
 ```
 
-Now that is installed, to activate it again you simply run the following command.  
+Now that is installed, to activate it again you simply run the following command.
 
 ```sh
 ./actions-runner/run.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,21 +49,25 @@ This is a public repo, one cannot simply trust that a commit came from who it sa
 ## Building Artifacts
 
 Build the pip package. This will cache in the build folder and the final output will be in the dist folder. This package is deployed to [pypi](https://pypi.org/project/duplocloud-client/).
+
 ```sh
 python -m build
 ```
 
 Building a plugin. These plugins don't necessarily need to be on pypi. They are just included alongside the release in Github. The example below shows how to build the AWS plugin. Simply replace `aws` with whatever folder name is in the [`plugins`](./plugins/) directory.
+
 ```sh
 python -m build plugins/aws/ -o=dist
 ```
 
 Create a single binary build for the cli using pyinstaller. These are ultimately included in the Github release so Homebrew can use them. Check out the [`scripts/installer.spec`](./scripts/installer.spec) file for the pyinstaller configuration and the [`installer.yml`](./.github/workflows/installer.yml) workflow for more details.
+
 ```sh
 ./scripts/installer.spec
 ```
 
 Build the Homebrew formula from a tagged release. Normally only the pipeline will run this script which does properly choose the right git tag before running. This ensures the pip dependencies are correct when building the formula.
+
 ```sh
 ./scripts/formula.py v0.2.15
 ```
@@ -87,15 +91,19 @@ When Ready to publish a new version live, go to the [publish.yml](https://github
 The docker file uses a couple of stages to do a few different tasks. Mainly the official image is the runner target. The bin target is for generating multiarch binaries.
 
 Build the main image locally for your machine using compose.
+
 ```sh
 docker compose build duploctl
 ```
+
 Or use bake to for a multiarch image. You just can't export images that are not your arch locally. So use compose to actually build the image locally.
+
 ```sh
 docker buildx bake duploctl
 ```
 
 Use buildx to build the multiarch binaries. This will output the binaries to the `dist` folder. See the Pyinstaller section above for more details on building the binaries. This runs the Pyinstaller script inside the docker container and outputs the built binaries to the local directory. This only works for linux binaries, Windows is a big maybe.
+
 ```sh
 docker buildx bake duploctl-bin
 ```
@@ -105,10 +113,13 @@ docker buildx bake duploctl-bin
 The homebrew formula is built from the `scripts/formula.py` script. This script will use the current git tag to build the formula.
 
 First you need to get the frozen requirements for the formula. This is done by running the following command. This will do all local dependencies including dev only dependencies. The pipeline will make sure to only include the necessary dependencies.
+
 ```sh
 pip freeze --exclude-editable > requirements.txt
 ```
+
 Then generate the formula using the current git tag.
+
 ```sh
 ./scripts/formula.py
 ```

--- a/README.md
+++ b/README.md
@@ -1,40 +1,42 @@
-# Duplocloud Py Client  
+# Duplocloud Py Client
 
 [![Unit Tests](https://github.com/duplocloud/duploctl/actions/workflows/test_unit.yml/badge.svg)](https://github.com/duplocloud/duploctl/actions/workflows/test_unit.yml) [![PyPI - Version](https://img.shields.io/pypi/v/duplocloud-client?logo=pypi)](https://pypi.org/project/duplocloud-client/) [![Docker Image Version](https://img.shields.io/docker/v/duplocloud/duploctl?sort=semver&logo=Docker&label=docker&color=blue&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fduplocloud%2Fduploctl)](https://hub.docker.com/r/duplocloud/duploctl) [![GitHub Release](https://img.shields.io/github/v/release/duplocloud/duploctl?logo=github&label=Github&color=purple)
 ](https://github.com/duplocloud/duploctl) [![Static Badge](https://img.shields.io/badge/Docs-lightblue?logo=github)
 ](https://cli.duplocloud.com/)
 
-```duploctl``` is a cli and package to work with a Duplocloud portal. It is a CLI for interacting with Duplocloud resources, such as Tenants, and is designed to work seamlessly within CLI-based CI/CD pipelines. It is a fully extensible package and can be used as both a Python module and a CLI. 
+```duploctl``` is a cli and package to work with a Duplocloud portal. It is a CLI for interacting with Duplocloud resources, such as Tenants, and is designed to work seamlessly within CLI-based CI/CD pipelines. It is a fully extensible package and can be used as both a Python module and a CLI.
 
-## Installation  
+## Installation
 
 From PyPi:
-```
+
+```sh
 pip install duplocloud-client
 ```
 
-From Homebrew:  
+From Homebrew:
+
 ```sh
 brew install duplocloud/tap/duploctl
 ```
 
-## Usage 
+## Usage
 
-Use ```duploctl``` as a CLI or as a standalone Python module called by your custom script. 
+Use ```duploctl``` as a CLI or as a standalone Python module called by your custom script.
 
-### Configuration  
+### Configuration
 
-Use the following syntax for these global arguments:  
+Use the following syntax for these global arguments:
 
-| Arg | Env Var | Description | Default | Required |  
-| --- | ------- | ----------- | ------- | -------- |  
-| --host, -H | DUPLO_HOST | The host to connect to |  | Yes |  
-| --token, -T | DUPLO_TOKEN | The token to use for auth |  | Yes |  
-| --tenant, -t | DUPLO_TENANT | The tenant to use for auth | default | No |  
+| Arg | Env Var | Description | Default | Required |
+| --- | ------- | ----------- | ------- | -------- |
+| --host, -H | DUPLO_HOST | The host to connect to |  | Yes |
+| --token, -T | DUPLO_TOKEN | The token to use for auth |  | Yes |
+| --tenant, -t | DUPLO_TENANT | The tenant to use for auth | default | No |
 
-### CLI  
+### CLI
 
-CLI command syntax for invoking ```duploctl``` 
+CLI command syntax for invoking ```duploctl```
 
 ```sh
 duploctl <resource> <command> <args...>
@@ -45,6 +47,7 @@ duploctl <resource> <command> <args...>
 Full documentation is in the Wiki section.
 
 Configure `duploctl` access with environment variables:
+
 ```sh
 export DUPLO_HOST=https://example.duplocloud.net
 export DUPLO_TOKEN=AQAAA...
@@ -52,21 +55,25 @@ export DUPLO_TENANT=dev01
 ```
 
 List the services in a tenant:
+
 ```sh
 duploctl service list
 ```
 
 Register Profile for AWS:
+
 ```sh
 duploctl jit update_aws_config myportal
 ```
 
 Open AWS Web Console:
+
 ```sh
 duploctl jit web
 ```
 
 Get Kubernetes config:
+
 ```sh
 duploctl jit update_kubeconfig myinfra
 ```
@@ -81,7 +88,7 @@ t = duplo("tenant", "find", "mytenant")
 print(t)
 ```
 
-Spawn a client with a custom host and token from a Python script. This example loads a resource and runs a method manually. 
+Spawn a client with a custom host and token from a Python script. This example loads a resource and runs a method manually.
 
 ```python
 duplo = DuploClient.from_creds(host="https://example.duplocloud.net", token="mytoken")
@@ -89,4 +96,3 @@ tenants = duplo.load("tenant")
 t = tenants.find("mytenant")
 print(t)
 ```
-

--- a/src/duplo_resource/cronjob.py
+++ b/src/duplo_resource/cronjob.py
@@ -8,31 +8,35 @@ class DuploCronJob(DuploTenantResourceV3):
   """
   Duplo CronJob are scheduled jobs that run containers in a Kubernetes cluster.
   """
-  
+
   def __init__(self, duplo: DuploClient):
     super().__init__(duplo, "k8s/cronJob")
 
   @Command()
-  def update_image(self, 
-                   name: args.NAME, 
+  def update_image(self,
+                   name: args.NAME,
                    image: args.IMAGE):
     """Update the image of a cronjob.
-    
+
     Args:
       name (str): The name of the cronjob to update.
       image (str): The new image to use for the cronjob.
     """
     cronjob = self.find(name)
+
+    # Set IsAnyHostAllowed
+    self._set_is_any_host_allowed(cronjob)
+
     cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["image"] = image
     self.update(cronjob)
     return {"message": f"Successfully updated image for cronjob '{name}'"}
-  
+
   @Command()
-  def update_schedule(self, 
-                      name: args.NAME, 
+  def update_schedule(self,
+                      name: args.NAME,
                       cronschedule: args.CRONSCHEDULE) -> dict:
     """Update the schedule of a cronjob.
-    
+
     Args:
       name: The name of the cronjob to update.
       cronschedule: The new schedule to use for the cronjob.
@@ -40,6 +44,21 @@ class DuploCronJob(DuploTenantResourceV3):
       message: A success message.
     """
     cronjob = self.find(name)
+
+    # Set IsAnyHostAllowed
+    self._set_is_any_host_allowed(cronjob)
+
     cronjob["spec"]["schedule"] = cronschedule
     self.update(cronjob)
     return {"message": f"Successfully updated cron-schedule for cronjob '{name}'"}
+
+  def _set_is_any_host_allowed(self, cronjob: dict) -> None:
+    """Helper method to set the 'IsAnyHostAllowed' field based on cronjob annotations."""
+    # Check if the annotation "duplocloud.net/is-any-host-allowed" exists and set `IsAnyHostAllowed`
+    annotations = cronjob.get("metadata", {}).get("annotations", {})
+    is_any_host_allowed = annotations.get("duplocloud.net/is-any-host-allowed")
+
+    if is_any_host_allowed == "true":
+      cronjob["IsAnyHostAllowed"] = True
+    else:
+      cronjob["IsAnyHostAllowed"] = False

--- a/src/tests/test_cronjobs.py
+++ b/src/tests/test_cronjobs.py
@@ -4,11 +4,11 @@ from duplocloud.errors import DuploError
 from .conftest import get_test_data
 
 class TestCronjobs:
-  
+
   @pytest.mark.integration
   @pytest.mark.order(7)
   @pytest.mark.dependency(
-    name="update_cronjob_image", 
+    name="update_cronjob_image",
     depends=["find_tenant_resource"],
     scope='session')
   def test_update_image(self, duplo: DuploClient):
@@ -22,12 +22,12 @@ class TestCronjobs:
       assert o["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["image"] == "ubuntu:latest"
     except DuploError as e:
       pytest.fail(f"Failed to find tenant {name}: {e}")
-  
+
   @pytest.mark.integration
   @pytest.mark.order(7)
   @pytest.mark.dependency(
-    name="update_cronjob_schedule", 
-    depends=["find_tenant_resource"], 
+    name="update_cronjob_schedule",
+    depends=["find_tenant_resource"],
     scope='session')
   def test_update_schedule(self, duplo: DuploClient):
     kind = "cronjob"
@@ -40,6 +40,45 @@ class TestCronjobs:
       assert o["spec"]["schedule"] == "1 1 * * 0"
     except DuploError as e:
       pytest.fail(f"Failed to find tenant {name}: {e}")
-  
-  
 
+  @pytest.mark.integration
+  @pytest.mark.order(7)
+  @pytest.mark.dependency(name="is_any_host_allowed", depends=["find_tenant_resource"], scope='session')
+  def test_is_any_host_allowed_true(self, duplo: DuploClient):
+    kind = "cronjob"
+    r = duplo.load(kind)
+    body = get_test_data(kind)
+    name = r.name_from_body(body)
+
+    # Set the annotation to true
+    body["metadata"]["annotations"] = {"duplocloud.net/is-any-host-allowed": "true"}
+    r.create(body)
+
+    try:
+      o = r.find(name)
+      # Validate the IsAnyHostAllowed is True based on the annotation
+      assert o["IsAnyHostAllowed"] == True
+
+    except DuploError as e:
+      pytest.fail(f"Failed to find tenant {name}: {e}")
+
+  @pytest.mark.integration
+  @pytest.mark.order(8)
+  @pytest.mark.dependency(name="is_any_host_allowed", depends=["find_tenant_resource"], scope='session')
+  def test_is_any_host_allowed_false(self, duplo: DuploClient):
+    kind = "cronjob"
+    r = duplo.load(kind)
+    body = get_test_data(kind)
+    name = r.name_from_body(body)
+
+    # Set the annotation to false
+    body["metadata"]["annotations"] = {"duplocloud.net/is-any-host-allowed": "false"}
+    r.create(body)
+
+    try:
+      o = r.find(name)
+      # Validate the IsAnyHostAllowed is False based on the annotation
+      assert o["IsAnyHostAllowed"] == False
+
+    except DuploError as e:
+      pytest.fail(f"Failed to find tenant {name}: {e}")


### PR DESCRIPTION
## Describe Changes

- Added logic to CronJob Update to set `isAnyHostAllowed`. We need to explicitly set this because of the choices made in the API design. Fixing the underlying problem would require making changes to our UI, Backend, and Terraform and deploying hotfixes to customers. 

## Link to Issues 

[DUPLO-25186](https://app.clickup.com/t/8655600/DUPLO-25186)

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
