### PR TITLE
DUPLO-26299 Rename duploctl Directive to duploctl-base

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -65,7 +65,7 @@ jobs:
         GIT_TAG: ${{ inputs.tag }}
       with:
         type: bake
-        target: duploctl
+        target: duploctl-base
         push: ${{ inputs.push }}
         docker-username: ${{ secrets.DOCKER_USERNAME }}
         docker-password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -91,7 +91,7 @@
       "group": "build",
       "command": "docker",
       "args": [
-        "buildx", "bake", "duploctl"
+        "buildx", "bake", "duploctl-base"
       ]
     },
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ docker compose build duploctl
 Or use bake to for a multiarch image. You just can't export images that are not your arch locally. So use compose to actually build the image locally.
 
 ```sh
-docker buildx bake duploctl
+docker buildx bake duploctl-base
 ```
 
 Use buildx to build the multiarch binaries. This will output the binaries to the `dist` folder. See the Pyinstaller section above for more details on building the binaries. This runs the Pyinstaller script inside the docker container and outputs the built binaries to the local directory. This only works for linux binaries, Windows is a big maybe.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
 
-  duploctl: &base
+  duploctl-base: &base
     image: &image duplocloud/duploctl:latest
     build: 
       target: runner


### PR DESCRIPTION
### **User description**
## Describe Changes

Rename duploctl Directive to duploctl-base to fix build issue.

## Link to Issues

[DUPLO-26299](https://app.clickup.com/t/8655600/DUPLO-26299)

Related: [docker/compose 12235](https://github.com/docker/compose/issues/12235#issuecomment-2445030390)

___

### **PR Type**
enhancement


___

### **Description**
- Renamed the `duploctl` directive to `duploctl-base` across multiple configuration files to address a build issue.
- Updated the GitHub Actions workflow to use the new target name.
- Modified VSCode tasks to reflect the new directive name.
- Updated the Docker Compose configuration to rename the service.
- Revised the contributing guide to include the updated build command.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>image.yml</strong><dd><code>Rename build target in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/image.yml

- Renamed build target from `duploctl` to `duploctl-base`.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/114/files#diff-113df80dfdb383808d66c98190c3f60ea45745427f926da3b04f572ff081d8a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.json</strong><dd><code>Update VSCode tasks to new directive name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/tasks.json

<li>Updated task arguments to use <code>duploctl-base</code> instead of <code>duploctl</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/114/files#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yaml</strong><dd><code>Rename service in Docker Compose configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yaml

- Renamed service from `duploctl` to `duploctl-base`.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/114/files#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Update contributing guide with new build command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

- Changed build command example to use `duploctl-base`.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/114/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information