### PR TITLE
DUPLO-30344: Added generic exception block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a generic exception block to handle any unexpected errors that are not instances of DuploError.
+
 ## [0.2.46] - 2025-03-03
 
 ### Fixed 

--- a/src/duplocloud/cli.py
+++ b/src/duplocloud/cli.py
@@ -11,6 +11,9 @@ def main():
   except DuploError as e:
     print(e)
     exit(e.code)
+  except Exception as e:
+    print(f"An unexpected error occurred: {e}")
+    exit(1)
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
## Describe Changes

Added a generic exception block to handle any unexpected errors that are not instances of DuploError, improving overall robustness.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30344

## PR Review Checklist  

- Thoroughly reviewed on local machine.
- Make sure to note changes in Changelog
