### PR TITLE
Patch config file into test_at_least_host.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 
 
+- Patch config file into test_at_least_host so it doesn't depend on a specific local setup.
 - Added a generic exception block to handle any unexpected errors that are not instances of DuploError.
 
 ### Added

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -15,8 +15,25 @@ def test_new_config():
   assert c.host == "https://example.duplocloud.net"
 
 @pytest.mark.unit
-def test_at_least_host():
+def test_at_least_host(mocker):
   """No Host Gets Error"""
+
+  # Patch in a mock of the client's config file so this test doesn't depend on a specific local setup.
+  # Alternatively, we could set the config_file arg of DuploClient to a YAML in the tests/files directory. A mock
+  # exercises the constructor's default (and requires no changes to the test this was added to fix).
+  duplo_config_file = '''
+---
+current-context: this
+contexts:
+- name: this
+  tenant: none
+  token: none
+
+  # Host not set to intentionally trigger the expected error.
+  # host: localhost
+'''
+  mocker.patch('builtins.open', mocker.mock_open(read_data=duplo_config_file))
+
   duplo = DuploClient()
   with pytest.raises(DuploError) as e:
     duplo.token


### PR DESCRIPTION
### **User description**
## Describe Changes

Patch config file into test_at_least_host. This ensures it doesn't depend on a specific local config being present, which means it will pass out of box for new users.

I noticed this while setting up my local env to work on #132, but the tests passed in the build so I didn't do anything about it in that branch. Turns out the test's behavior depends on a config file with a specific omission. The builds must have that present. This patch makes it so you can clone the repo and do nothing else and the unit tests will pass.

## Link to Issues  

N/A.

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog

    ~~I didn't add anything to the changelog because this doesn't change anything in duploctl.~~
    
    ~~The [keep a changelog guide talks about some changes not being needed](https://keepachangelog.com/en/1.1.0/#bad-practices):~~

    ~~> for instance, removing a single whitespace may not need to be recorded in all instances~~
    
    ~~Patching a unit test so it passes for new users seemed like it fit into that category. It's debatable because the patch technically changes test behavior which could potentially have some impact on future development, but that feels like a slim enough connection that it would just be noise in the changelog.~~
    
    ~~Can add to changelog if that's preferred though, no problem.~~
    
    Nevermind notes above, looks like the repo has automation that requires changelog updates on all PRs.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Patched `test_at_least_host` to use a mock config file.

- Ensured the test no longer depends on local configurations.

- Improved test reliability for new users out of the box.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Mocked config file for `test_at_least_host`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_client.py

<li>Added a mock configuration file for <code>test_at_least_host</code>.<br> <li> Used <code>mocker.patch</code> to simulate file reading.<br> <li> Ensured the test triggers the expected error without a host.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/133/files#diff-ab1481a5b2621599bcf22b8e88a27ad8c8938e9806c151c75b9104cd5bb9560a">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>