### PR TITLE
DUPLO-30659: Enhanced configmap commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unit tests for missing service methods: create, delete, start, restart and stop.
 - Added integration tests for missing ASG methods: list, find, create, update, delete and scale.
 - Added integration tests for AWS Secret methods: find, create, update and delete.
+- Added configmap commands (find, delete, update) with integration tests.
 
 ## [0.2.46] - 2025-03-03
 

--- a/src/tests/test_configmap.py
+++ b/src/tests/test_configmap.py
@@ -1,0 +1,65 @@
+import pytest
+import time
+from duplocloud.errors import DuploError
+from .conftest import get_test_data
+
+@pytest.fixture(scope="class")
+def configmap_resource(duplo, request):
+    """Fixture to load the ConfigMap resource and ensure ConfigMap name persists across tests."""
+    resource = duplo.load("configmap")
+    tenant = resource.tenant["AccountName"]
+    request.cls.configmap_name = None
+    return resource
+
+def execute_test(func, *args, **kwargs):
+    """Helper function to execute a test and handle errors."""
+    try:
+        return func(*args, **kwargs)
+    except DuploError as e:
+        pytest.fail(f"Test failed: {e}")
+
+@pytest.mark.usefixtures("configmap_resource")
+class TestConfigMap:
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(name="create_configmap", scope="class")
+    @pytest.mark.order(5)
+    def test_create_configmap(self, configmap_resource, request):
+        """Test creating a ConfigMap and store name at class level."""
+        r = configmap_resource
+        body = get_test_data("configmap")
+        response = execute_test(r.create, body=body, wait=True)
+        assert "name" in response["metadata"], "ConfigMap name missing in response"
+        request.cls.configmap_name = response["metadata"]["name"]
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_configmap"], scope="class")
+    @pytest.mark.order(6)
+    def test_update_configmap(self, configmap_resource, request):
+        """Test updating a ConfigMap using stored ConfigMap name."""
+        r = configmap_resource
+        assert self.configmap_name is not None, "ConfigMap name not found! Ensure test_create_configmap ran successfully."
+        update_body = get_test_data("configmap")
+        response = execute_test(r.update, name=self.configmap_name, body=update_body)
+        assert "name" in response["metadata"], "ConfigMap name missing in response"
+        assert response["metadata"]["name"] == self.configmap_name, "ConfigMap name mismatch after update"
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_configmap"], scope="session")
+    @pytest.mark.order(7)
+    def test_list_configmap(self, configmap_resource):
+        """Test listing ConfigMaps."""
+        r = configmap_resource
+        configmaps = execute_test(r.list)
+        assert isinstance(configmaps, list), "ConfigMap list response is not a list"
+        assert len(configmaps) > 0, "No ConfigMaps found"
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_configmap"], scope="session")
+    @pytest.mark.order(997)
+    def test_delete_configmap(self, configmap_resource):
+        """Test deleting a ConfigMap."""
+        r = configmap_resource
+        assert self.configmap_name is not None, "ConfigMap name not found!"
+        response = execute_test(r.delete, name=self.configmap_name)
+        assert response.get("message") == f"Successfully deleted configmap '{self.configmap_name}'"


### PR DESCRIPTION
### **User description**
## Describe Changes

Improving the functionality of dupoctl configmap commands by adding missing commands, and ensuring robust integration tests.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30659

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added new `update`, `find`, and `delete` commands for ConfigMap management.

- Enhanced `create` command with improved error handling and return types.

- Introduced integration tests for ConfigMap operations (create, update, list, delete).

- Updated changelog to reflect new ConfigMap commands and tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configmap.py</strong><dd><code>Add new ConfigMap commands and enhance existing ones</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/configmap.py

<li>Added <code>update</code>, <code>find</code>, and <code>delete</code> commands for ConfigMap management.<br> <li> Enhanced <code>create</code> command with improved error handling and return types.<br> <li> Improved documentation for ConfigMap commands.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/138/files#diff-31f4cddaf99622814bb1a9e23c6c39cd5d423a2defc34e6e8bb92291a2e17163">+82/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_configmap.py</strong><dd><code>Add integration tests for ConfigMap commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_configmap.py

<li>Added integration tests for ConfigMap commands (create, update, list, <br>delete).<br> <li> Introduced helper function for error handling in tests.<br> <li> Used pytest fixtures and dependencies for test organization.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/138/files#diff-5bb8ee5de162c1f814347ea8e74a31f04d8055931121cef5b26f189053ed45b1">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with ConfigMap enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented new ConfigMap commands (find, delete, update).<br> <li> Mentioned addition of integration tests for ConfigMap operations.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/138/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>