### PR TITLE
DUPLO-30696: Fix dupoctl ingress commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Patch config file into test_at_least_host so it doesn't depend on a specific local setup.
 - Added a generic exception block to handle any unexpected errors that are not instances of DuploError.
+- Existing ingress commands (create, update) with missing integration tests.
 
 ### Added
 

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -1,9 +1,71 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV3
-from duplocloud.commander import Resource
+from duplocloud.commander import Resource, Command
+import duplocloud.args as args
 
 @Resource("ingress")
 class DuploIngress(DuploTenantResourceV3):
   
   def __init__(self, duplo: DuploClient):
     super().__init__(duplo, "k8s/ingress")
+
+  def name_from_body(self, body):
+    return body["name"]
+
+  @Command()
+  def create(self, body: args.BODY) -> dict:
+    """Create an Ingress.
+    Usage: CLI Usage
+      ```sh
+      duploctl ingress create -f 'ingress.yaml'
+      ```
+      Contents of the `ingress.yaml` file
+      ```yaml
+      --8<-- "src/tests/data/ingress.yaml"
+      ```
+    Example: One liner example
+      ```sh
+      echo \"\"\"
+      --8<-- "src/tests/data/ingress.yaml"
+      \"\"\" | duploctl ingress create -f -
+      ```
+    Args:
+      body: The resource to create.
+    Returns: 
+      dict: The created resource or success message.
+    """
+    name = self.name_from_body(body)
+    response = self.duplo.post(self.endpoint(), body)
+    return {
+      "message": f"Successfully Created an Ingress '{name}'",
+      "data": response.json()
+    }
+
+  @Command()
+  def update(self, body: args.BODY) -> dict:
+    """Update an Ingress.
+    Usage: CLI Usage
+      ```sh
+      duploctl ingress update -f 'ingress.yaml'
+      ```
+      Contents of the `ingress.yaml` file
+      ```yaml
+      --8<-- "src/tests/data/ingress.yaml"
+      ```
+    Example: One liner example
+      ```sh
+      echo \"\"\"
+      --8<-- "src/tests/data/ingress.yaml"
+      \"\"\" | duploctl ingress update -f -
+      ```
+    Args:
+      body: The resource to update.
+    Returns: 
+      dict: The updated resource or success message.
+    """
+    name = self.name_from_body(body)
+    response = self.duplo.put(self.endpoint(name), body)
+    return {
+      "message": f"Successfully Updated an Ingress '{name}'",
+      "data": response.json()
+    }

--- a/src/tests/data/ingress.yaml
+++ b/src/tests/data/ingress.yaml
@@ -1,0 +1,22 @@
+labels: null
+annotations: null
+lbConfig:
+  listeners:
+    https:
+      - 443
+    http:
+      - 80
+  dnsPrefix: "duploctl"
+  isPublic: true
+  certArn:
+rules:
+  - path: "/"
+    pathType: "Prefix"
+    serviceName: "nginx"
+    port: 80
+    host: "duploctl-nginx.duplocloud.net"
+    portName: null
+name: "duploctl"
+ingressClassName: "alb"
+otherSpecs:
+  tls: []

--- a/src/tests/test_ingress.py
+++ b/src/tests/test_ingress.py
@@ -1,0 +1,60 @@
+import pytest
+from duplocloud.errors import DuploError
+from .conftest import get_test_data
+
+@pytest.fixture(scope="class")
+def ingress_resource(duplo, request):
+    """Fixture to load an Ingress resource."""
+    resource = duplo.load("ingress")
+    request.cls.ingress_name = None
+    return resource
+
+def execute_test(func, *args, **kwargs):
+    """Helper function to execute a test and handle errors."""
+    try:
+        return func(*args, **kwargs)
+    except DuploError as e:
+        pytest.fail(f"Test failed: {e}")
+
+class TestIngress:
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(name="create_ingress", scope="session")
+    @pytest.mark.order(6)
+    def test_create_ingress(self, ingress_resource, request):
+        """Test creating an Ingress resource."""
+        r = ingress_resource
+        body = get_test_data("ingress")
+        response = execute_test(r.create, body=body)
+        assert response.get("message") and f"Successfully Created an Ingress '{body['name']}'" in response["message"], "Ingress creation failed"
+        request.cls.ingress_name = body['name']
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_ingress"], scope="session")
+    @pytest.mark.order(7)
+    def test_update_ingress(self, ingress_resource):
+        """Test updating an Ingress resource."""
+        r = ingress_resource
+        update_body = get_test_data("ingress")
+        response = execute_test(r.update, body=update_body)
+        assert response.get("message") and f"Successfully Updated an Ingress '{update_body['name']}'" in response["message"], "Ingress updation failed"
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_ingress"], scope="session")
+    @pytest.mark.order(8)
+    def test_list_ingress(self, ingress_resource):
+        """Test listing an Ingress."""
+        r = ingress_resource
+        ingresses = execute_test(r.list)
+        assert isinstance(ingresses, list), "Ingress list response is not a list"
+        assert len(ingresses) > 0, "No Ingress found"
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_ingress"], scope="session")
+    @pytest.mark.order(997)
+    def test_delete_ingress(self, ingress_resource):
+        """Test deleting an Ingress."""
+        r = ingress_resource
+        assert self.ingress_name is not None, "Ingress name not found!"
+        response = execute_test(r.delete, name=self.ingress_name)
+        assert response.get("message") == f"k8s/ingress/{self.ingress_name} deleted"


### PR DESCRIPTION
### **User description**
## Describe Changes

Improved the functionality of dupoctl ingress commands by fixing following existing commands, and ensuring robust integration tests.

1. create
2. update 

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30696

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `create` and `update` commands for managing Ingress resources.

- Introduced integration tests for Ingress commands: create, update, list, delete.

- Updated `CHANGELOG.md` to reflect new Ingress command tests.

- Added sample Ingress YAML configuration for testing purposes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingress.py</strong><dd><code>Added create and update commands for Ingress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/ingress.py

<li>Added <code>create</code> command for creating Ingress resources.<br> <li> Added <code>update</code> command for updating Ingress resources.<br> <li> Introduced helper method <code>name_from_body</code> for extracting resource names.<br> <li> Enhanced command documentation with usage examples.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/139/files#diff-65cd541c7446f6f21cc348e536972c48c2e664daf2dac9cc40fbb14ccc98b571">+63/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ingress.py</strong><dd><code>Added integration tests for Ingress commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_ingress.py

<li>Added integration tests for Ingress commands: create, update, list, <br>delete.<br> <li> Utilized pytest fixtures and dependencies for test setup and <br>execution.<br> <li> Included error handling for test execution.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/139/files#diff-5a84b92f99959e2532a258881ff841f5ddb257d0bdadf822f8eff7af7650d94e">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ingress.yaml</strong><dd><code>Added sample Ingress YAML configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/data/ingress.yaml

<li>Added sample YAML configuration for Ingress resources.<br> <li> Included fields for labels, annotations, lbConfig, rules, and other <br>specs.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/139/files#diff-49b3b41a53fb07c1797ba544221f9c94743945e2524359835203e03c30a84f80">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog with Ingress test details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Documented addition of integration tests for Ingress commands.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/139/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>