### PR TITLE
DUPLO-30803: Added DuploStillWaiting class for resource waiting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added DuploStillWaiting class to reflect scenarios where a command waits too long for a resource operation to complete.
+
 ## [0.2.47] - 2025-04-07
 
 ### Fixed 

--- a/src/duplo_resource/cloudfront.py
+++ b/src/duplo_resource/cloudfront.py
@@ -1,6 +1,6 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV3
-from duplocloud.errors import DuploError, DuploFailedResource
+from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -21,7 +21,7 @@ class CloudFront(DuploTenantResourceV3):
       elif status in ["failed", "error"]:
         raise DuploFailedResource(f"CloudFront distribution {distribution_id} failed to deploy.")
       else:
-        raise DuploError(f"Timed out waiting for CloudFront {distribution_id} to be deployed.")
+        raise DuploStillWaiting(f"Timed out waiting for CloudFront {distribution_id} to be deployed.")
 
     @Command()
     def find(self, distribution_id: args.DISTRIBUTION_ID):

--- a/src/duplo_resource/ecs_service.py
+++ b/src/duplo_resource/ecs_service.py
@@ -1,6 +1,6 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV2
-from duplocloud.errors import DuploError
+from duplocloud.errors import DuploError, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -275,4 +275,4 @@ class DuploEcsService(DuploTenantResourceV2):
     # filter the tasks down to any where the DesiredStatus and LastStatus are different
     running_tasks = [t for t in tasks if t["DesiredStatus"] != t["LastStatus"]]
     if len(running_tasks) > 0:
-      raise DuploError(f"Service {name} waiting for replicas update", 400)
+      raise DuploStillWaiting(f"Service {name} waiting for replicas update")

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -1,6 +1,6 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV2
-from duplocloud.errors import DuploError, DuploFailedResource
+from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -55,7 +55,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "running":
         if h["Status"] != "pending":
           raise DuploFailedResource(f"Host '{name}' failed to create.")
-        raise DuploError(f"Host '{name}' not ready", 404)
+        raise DuploStillWaiting(f"Host '{name}' not ready")
     # let's get started
     if body.get("ImageId", None) is None:
       body["ImageId"] = self.discover_image(body.get("AgentPlatform", 0))
@@ -100,7 +100,7 @@ class DuploHosts(DuploTenantResourceV2):
         else:
           raise DuploFailedResource(f"Host '{name}' failed to delete.")
       if h["Status"] == "shutting-down" or h["Status"] == "running":
-        raise DuploError(f"Host '{name}' not terminated", 404)
+        raise DuploStillWaiting(f"Host '{name}' not terminated")
     if wait:
       self.wait(wait_check, 500)
     return {
@@ -138,7 +138,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "stopped":
         if h["Status"] != "stopping":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
-        raise DuploError(f"Host '{name}' not ready", 404)
+        raise DuploStillWaiting(f"Host '{name}' not ready")
     if wait:
       self.wait(wait_check, 500)
     return {
@@ -176,7 +176,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "running":
         if h["Status"] != "pending":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
-        raise DuploError(f"Host '{name}' not ready", 404)
+        raise DuploStillWaiting(f"Host '{name}' not ready")
     if wait:
       self.wait(wait_check, 500)
     return {

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -55,7 +55,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "running":
         if h["Status"] != "pending":
           raise DuploFailedResource(f"Host '{name}' failed to create.")
-        raise DuploStillWaiting(f"Host '{name}' not ready")
+        raise DuploStillWaiting(f"Host '{name}' is waiting")
     # let's get started
     if body.get("ImageId", None) is None:
       body["ImageId"] = self.discover_image(body.get("AgentPlatform", 0))
@@ -100,7 +100,7 @@ class DuploHosts(DuploTenantResourceV2):
         else:
           raise DuploFailedResource(f"Host '{name}' failed to delete.")
       if h["Status"] == "shutting-down" or h["Status"] == "running":
-        raise DuploStillWaiting(f"Host '{name}' not terminated")
+        raise DuploStillWaiting(f"Host '{name}' is waiting for termination")
     if wait:
       self.wait(wait_check, 500)
     return {
@@ -138,7 +138,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "stopped":
         if h["Status"] != "stopping":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
-        raise DuploStillWaiting(f"Host '{name}' not ready")
+        raise DuploStillWaiting(f"Host '{name}' is waiting for status stopped")
     if wait:
       self.wait(wait_check, 500)
     return {
@@ -176,7 +176,7 @@ class DuploHosts(DuploTenantResourceV2):
       if h["Status"] != "running":
         if h["Status"] != "pending":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
-        raise DuploStillWaiting(f"Host '{name}' not ready")
+        raise DuploStillWaiting(f"Host '{name}' is waiting for status running")
     if wait:
       self.wait(wait_check, 500)
     return {

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -1,5 +1,5 @@
 from duplocloud.client import DuploClient
-from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
+from duplocloud.errors import DuploFailedResource, DuploStillWaiting
 from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -48,7 +48,7 @@ class DuploInfrastructure(DuploResource):
         # stop waiting if the status contains failed
         if "Failed" in s:
           raise DuploFailedResource(f"Infrastructure '{name} - {s}'")
-        raise DuploStillWaiting(None)
+        raise DuploStillWaiting(f"Infrastructure '{name}' is waiting for status Complete")
     self.duplo.post("adminproxy/CreateInfrastructureConfig", body)
     if wait:
       self.wait(wait_check, 1800, 20)

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -1,5 +1,5 @@
 from duplocloud.client import DuploClient
-from duplocloud.errors import DuploError, DuploFailedResource
+from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
 from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
@@ -48,7 +48,7 @@ class DuploInfrastructure(DuploResource):
         # stop waiting if the status contains failed
         if "Failed" in s:
           raise DuploFailedResource(f"Infrastructure '{name} - {s}'")
-        raise DuploError(None, 404)
+        raise DuploStillWaiting(None)
     self.duplo.post("adminproxy/CreateInfrastructureConfig", body)
     if wait:
       self.wait(wait_check, 1800, 20)

--- a/src/duplo_resource/job.py
+++ b/src/duplo_resource/job.py
@@ -68,7 +68,7 @@ class DuploJob(DuploTenantResourceV3):
       
       # if none have completed, keep waiting
       if not len(cpl) > 0:
-        raise DuploStillWaiting(f"Job {name} not complete {cpl}")
+        raise DuploStillWaiting(f"Job '{name}' is waiting for 'Complete' condition")
     super().create(body, wait, wait_check)
     return {
       "message": f"Job {name} ran successfully."

--- a/src/duplo_resource/job.py
+++ b/src/duplo_resource/job.py
@@ -1,5 +1,5 @@
 from duplocloud.client import DuploClient  # Importing necessary modules
-from duplocloud.errors import DuploError, DuploFailedResource
+from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
 from duplocloud.resource import DuploTenantResourceV3
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
@@ -68,7 +68,7 @@ class DuploJob(DuploTenantResourceV3):
       
       # if none have completed, keep waiting
       if not len(cpl) > 0:
-        raise DuploError(f"Job {name} not complete {cpl}")
+        raise DuploStillWaiting(f"Job {name} not complete {cpl}")
     super().create(body, wait, wait_check)
     return {
       "message": f"Job {name} ran successfully."

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -1,7 +1,7 @@
 import time
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV2
-from duplocloud.errors import DuploError, DuploFailedResource
+from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 from json import dumps, loads
 import duplocloud.args as args
@@ -701,11 +701,11 @@ class DuploService(DuploTenantResourceV2):
       replicas = svc["Replicas"]
       # make sure the change has been applied
       if (image_changed and self.image_from_body(svc) != new_img):
-        raise DuploError(f"Service {name} waiting for image update", 400)
+        raise DuploStillWaiting(f"Service {name} waiting for image update")
       if (replicas_changed and replicas != new_replicas):
-        raise DuploError(f"Service {name} waiting for replicas update", 400)
+        raise DuploStillWaiting(f"Service {name} waiting for replicas update")
       if (conf_changed and svc["Template"].get("OtherDockerConfig", None) != new_conf):
-        raise DuploError(f"Service {name} waiting for pod to update", 400)
+        raise DuploStillWaiting(f"Service {name} waiting for pod to update")
       pods = self.pods(name)
       faults = self.tenant_svc.faults(id=self.tenant_id)
       running = 0
@@ -737,7 +737,7 @@ class DuploService(DuploTenantResourceV2):
 
       # make sure all the replicas are up
       if replicas != running:
-        raise DuploError(f"Service {name} waiting for pods {running}/{replicas}", 400)
+        raise DuploStillWaiting(f"Service {name} waiting for pods {running}/{replicas}")
       
     # send to the base class to do the waiting
     super().wait(wait_check, 400, 11)

--- a/src/duplocloud/errors.py
+++ b/src/duplocloud/errors.py
@@ -19,3 +19,8 @@ class DuploFailedResource(DuploError):
   """Raised when a Duplo resource is in a failed state."""
   def __init__(self, name: str):
     super().__init__(f"{name} is in a failed state", 412)
+
+class DuploStillWaiting(DuploError):
+  """Raised when a Duplo resource is in a waiting state."""
+  def __init__(self, name: str):
+    super().__init__(f"{name} is in a waiting state", 408)

--- a/src/duplocloud/resource.py
+++ b/src/duplocloud/resource.py
@@ -1,6 +1,6 @@
 from . import args
 from .client import DuploClient
-from .errors import DuploError, DuploFailedResource
+from .errors import DuploError, DuploFailedResource, DuploStillWaiting
 from .commander import get_parser, extract_args, Command
 import math
 import time
@@ -57,7 +57,7 @@ class DuploResource():
       except KeyboardInterrupt as e:
         raise e
     else:
-      raise DuploError("Timed out waiting", 404)
+      raise DuploStillWaiting("Timed out waiting")
     
 class DuploResourceV2(DuploResource):
 

--- a/src/duplocloud/resource.py
+++ b/src/duplocloud/resource.py
@@ -50,7 +50,7 @@ class DuploResource():
         break
       except DuploFailedResource as e:
         raise e
-      except DuploError as e:
+      except DuploStillWaiting as e:
         if e.message:
           self.duplo.logger.debug(e)
         time.sleep(poll)

--- a/src/tests/test_errors.py
+++ b/src/tests/test_errors.py
@@ -1,0 +1,51 @@
+import pytest
+from duplocloud.errors import DuploError, DuploExpiredCache, DuploFailedResource, DuploStillWaiting
+
+@pytest.mark.unit
+def test_duplo_error_defaults():
+    err = DuploError("Something went wrong")
+    assert isinstance(err, DuploError)
+    assert str(err) == "Something went wrong"
+    assert err.code == 1
+    assert err.response is None
+
+@pytest.mark.unit
+def test_duplo_error_custom_code():
+    err = DuploError("Custom code", code=500)
+    assert err.code == 500
+
+@pytest.mark.unit
+def test_duplo_expired_cache():
+    key = "test_key"
+    err = DuploExpiredCache(key)
+    assert isinstance(err, DuploExpiredCache)
+    assert isinstance(err, DuploError)
+    assert err.key == key
+    assert err.code == 404
+    assert str(err) == "Cache item {key} is expired"
+
+@pytest.mark.unit
+def test_duplo_failed_resource():
+    err = DuploFailedResource("test-resource")
+    assert isinstance(err, DuploFailedResource)
+    assert err.code == 412
+    assert str(err) == "test-resource is in a failed state"
+
+@pytest.mark.unit
+def test_duplo_still_waiting():
+    err = DuploStillWaiting("delayed-service")
+    assert isinstance(err, DuploStillWaiting)
+    assert err.code == 408
+    assert str(err) == "delayed-service is in a waiting state"
+
+@pytest.mark.integration
+@pytest.mark.parametrize("exception_class,init_arg,expected_str,expected_code", [
+    (DuploExpiredCache, "mykey", "Cache item {key} is expired", 404),
+    (DuploFailedResource, "resource-A", "resource-A is in a failed state", 412),
+    (DuploStillWaiting, "resource-B", "resource-B is in a waiting state", 408),
+])
+def test_integration_duplo_exceptions(exception_class, init_arg, expected_str, expected_code):
+    err = exception_class(init_arg)
+    assert isinstance(err, DuploError)
+    assert str(err) == expected_str
+    assert err.code == expected_code


### PR DESCRIPTION
## Describe Changes

Added DuploStillWaitingResource exception to handle cases where a Duplo resource remains in a waiting state. 

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30803

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
