### PR TITLE
DUPLO-30983: Added patching support and docs enhancements for an Ingress resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Patching support and docs enhancements were added for an Ingress.
+
 ## [0.2.47] - 2025-04-07
 
 ### Fixed 

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -6,6 +6,12 @@ import duplocloud.args as args
 
 @Resource("ingress")
 class DuploIngress(DuploTenantResourceV3):
+  """Kubernetes Ingress
+
+  This class offers methods to manage Kubernetes Ingress within DuploCloud.
+  See more details at:
+  https://docs.duplocloud.com/docs/kubernetes-overview/ingress-loadbalancer
+  """
   
   def __init__(self, duplo: DuploClient):
     super().__init__(duplo, "k8s/ingress")
@@ -64,7 +70,7 @@ class DuploIngress(DuploTenantResourceV3):
              patches: args.PATCHES = None) -> dict:
     """Update an Ingress resource.
 
-    Update an exisitng Ingress resource with the specified metadata and data entries.
+    Update an existing Ingress resource with the specified metadata and data entries.
 
     Usage: CLI Usage
       ```sh
@@ -92,6 +98,16 @@ class DuploIngress(DuploTenantResourceV3):
       duploctl ingress update <ingress-name> --replace rules/0.port <port>
       ```
 
+    Example: Update ingress by adding an additional rule.
+      ```sh
+      duploctl ingress update <ingress-name> --add rules/- '{"path":"/","pathType":"Prefix","serviceName":"<service-name>","port":80,"host":"<host>","portName":null}'
+      ```
+
+    Example: Update ingress by removing a rule.
+      ```sh
+      duploctl ingress update <ingress-name> --remove rules/0
+      ```
+
     Args:
       name: The name of the Ingress resource to update. Required if `body` is not provided.\n
       body: The complete Ingress resource definition.\n
@@ -105,8 +121,6 @@ class DuploIngress(DuploTenantResourceV3):
     Raises:
       DuploError: If the Ingress could not be updated.
     """
-    if (name is None and body is None):
-      raise DuploError("No arguments provided to update ingress", 400)
     if name and body:
       if 'name' not in body or body['name'] != name:
         raise DuploError("Provided 'name' must match 'name' in the body.")

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -48,13 +48,13 @@ class DuploIngress(DuploTenantResourceV3):
       ```
 
     Args:
-      body: The complete Ingress resource definition.
+      body: The complete Ingress resource definition including name, rules, and other configuration.
 
     Returns:
       message: The created resource or success message.
 
     Raises:
-      DuploError: If the Ingress could not be created.
+      DuploError: If the Ingress could not be created due to invalid configuration or API errors.
     """
     name = self.name_from_body(body)
     response = self.duplo.post(self.endpoint(), body)
@@ -71,6 +71,8 @@ class DuploIngress(DuploTenantResourceV3):
     """Update an Ingress resource.
 
     Update an existing Ingress resource with the specified metadata and data entries.
+    The update can be performed either by providing a complete resource definition or
+    by applying JSON patches to modify specific fields.
 
     Usage: CLI Usage
       ```sh
@@ -90,12 +92,12 @@ class DuploIngress(DuploTenantResourceV3):
 
     Example: Update dnsPrefix for an ingress.
       ```sh
-      duploctl ingress update <ingress-name> --replace lbConfig.dnsPrefix <value>
+      duploctl ingress update <ingress-name> --replace lbConfig/dnsPrefix <value>
       ```
 
     Example: Update port of a rule for an ingress.
       ```sh
-      duploctl ingress update <ingress-name> --replace rules/0.port <port>
+      duploctl ingress update <ingress-name> --replace rules/0/port <port>
       ```
 
     Example: Update ingress by adding an additional rule.
@@ -109,14 +111,14 @@ class DuploIngress(DuploTenantResourceV3):
       ```
 
     Args:
-      name: The name of the Ingress resource to update. Required if `body` is not provided.\n
-      body: The complete Ingress resource definition.\n
-      patches: A list of JSON patches as args to apply to the service.
+      name: The name of the Ingress resource to update. Required if `body` is not provided.
+      body: The complete Ingress resource definition with updated configuration.
+      patches: A list of JSON patches to apply to the Ingress resource.
         The options are `--add`, `--remove`, `--replace`, `--move`, and `--copy`.
         Then followed by `<path>` and `<value>` for `--add`, `--replace`, and `--test`.
 
     Returns:
-      message: The updated resource or success message.
+      message: The created resource or success message.
 
     Raises:
       DuploError: If the Ingress could not be updated.

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -92,22 +92,22 @@ class DuploIngress(DuploTenantResourceV3):
 
     Example: Update dnsPrefix for an ingress.
       ```sh
-      duploctl ingress update <ingress-name> --replace lbConfig/dnsPrefix <value>
+      duploctl ingress update <ingress-name> --replace /lbConfig/dnsPrefix <value>
       ```
 
     Example: Update port of a rule for an ingress.
       ```sh
-      duploctl ingress update <ingress-name> --replace rules/0/port <port>
+      duploctl ingress update <ingress-name> --replace /rules/0/port <port>
       ```
 
     Example: Update ingress by adding an additional rule.
       ```sh
-      duploctl ingress update <ingress-name> --add rules/- '{"path":"/","pathType":"Prefix","serviceName":"<service-name>","port":80,"host":"<host>","portName":null}'
+      duploctl ingress update <ingress-name> --add /rules/- '{"path":"/","pathType":"Prefix","serviceName":"<service-name>","port":80,"host":"<host>","portName":null}'
       ```
 
     Example: Update ingress by removing a rule.
       ```sh
-      duploctl ingress update <ingress-name> --remove rules/0
+      duploctl ingress update <ingress-name> --remove /rules/0
       ```
 
     Args:

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -1,5 +1,6 @@
 from duplocloud.client import DuploClient
 from duplocloud.resource import DuploTenantResourceV3
+from duplocloud.errors import DuploError
 from duplocloud.commander import Resource, Command
 import duplocloud.args as args
 
@@ -13,26 +14,41 @@ class DuploIngress(DuploTenantResourceV3):
     return body["name"]
 
   @Command()
-  def create(self, body: args.BODY) -> dict:
-    """Create an Ingress.
+  def create(self,
+             body: args.BODY) -> dict:
+    """Create an Ingress resource.
+
+    Creates a new Ingress resource with the specified metadata and data entries.
+
     Usage: CLI Usage
       ```sh
-      duploctl ingress create -f 'ingress.yaml'
+      duploctl ingress create -f ingress.yaml
       ```
       Contents of the `ingress.yaml` file
       ```yaml
       --8<-- "src/tests/data/ingress.yaml"
       ```
-    Example: One liner example
+
+    Example: Create an Ingress using a one-liner.
       ```sh
       echo \"\"\"
       --8<-- "src/tests/data/ingress.yaml"
       \"\"\" | duploctl ingress create -f -
       ```
+
+    Example: Create an Ingress using a file.
+      ```sh
+      duploctl ingress create -f ingress.yaml
+      ```
+
     Args:
-      body: The resource to create.
-    Returns: 
-      dict: The created resource or success message.
+      body: The complete Ingress resource definition.
+
+    Returns:
+      message: The created resource or success message.
+
+    Raises:
+      DuploError: If the Ingress could not be created.
     """
     name = self.name_from_body(body)
     response = self.duplo.post(self.endpoint(), body)
@@ -42,30 +58,62 @@ class DuploIngress(DuploTenantResourceV3):
     }
 
   @Command()
-  def update(self, body: args.BODY) -> dict:
-    """Update an Ingress.
+  def update(self,
+             name: args.NAME,
+             body: args.BODY = None,
+             patches: args.PATCHES = None) -> dict:
+    """Update an Ingress resource.
+
+    Update an exisitng Ingress resource with the specified metadata and data entries.
+
     Usage: CLI Usage
       ```sh
-      duploctl ingress update -f 'ingress.yaml'
+      duploctl configmap update -f ingress.yaml
       ```
       Contents of the `ingress.yaml` file
       ```yaml
       --8<-- "src/tests/data/ingress.yaml"
       ```
-    Example: One liner example
+
+    Example: Update ingress using a one-liner.
       ```sh
       echo \"\"\"
       --8<-- "src/tests/data/ingress.yaml"
       \"\"\" | duploctl ingress update -f -
       ```
+
+    Example: Update dnsPrefix for an ingress.
+      ```sh
+      duploctl ingress update <ingress-name> --replace lbConfig.dnsPrefix <value>
+      ```
+
+    Example: Update port of a rule for an ingress.
+      ```sh
+      duploctl ingress update <ingress-name> --replace rules/0.port <port>
+      ```
+
     Args:
-      body: The resource to update.
-    Returns: 
-      dict: The updated resource or success message.
+      name: The name of the Ingress resource to update. Required if `body` is not provided.\n
+      body: The complete Ingress resource definition.\n
+      patches: A list of JSON patches as args to apply to the service.
+        The options are `--add`, `--remove`, `--replace`, `--move`, and `--copy`.
+        Then followed by `<path>` and `<value>` for `--add`, `--replace`, and `--test`.
+
+    Returns:
+      message: The updated resource or success message.
+
+    Raises:
+      DuploError: If the Ingress could not be updated.
     """
-    name = self.name_from_body(body)
-    response = self.duplo.put(self.endpoint(name), body)
+    if (name is None and body is None):
+      raise DuploError("No arguments provided to update ingress", 400)
+    if name and body:
+      if 'name' not in body or body['name'] != name:
+        raise DuploError("Provided 'name' must match 'name' in the body.")
+    if body is None:
+      body = self.find(name)
+    response = super().update(name=name, body=body, patches=patches)
     return {
       "message": f"Successfully Updated an Ingress '{name}'",
-      "data": response.json()
+      "data": response
     }

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -68,7 +68,7 @@ class DuploIngress(DuploTenantResourceV3):
 
     Usage: CLI Usage
       ```sh
-      duploctl configmap update -f ingress.yaml
+      duploctl ingress update -f ingress.yaml
       ```
       Contents of the `ingress.yaml` file
       ```yaml

--- a/src/duplo_resource/ingress.py
+++ b/src/duplo_resource/ingress.py
@@ -9,8 +9,8 @@ class DuploIngress(DuploTenantResourceV3):
   """Kubernetes Ingress
 
   This class offers methods to manage Kubernetes Ingress within DuploCloud.
-  See more details at:
-  https://docs.duplocloud.com/docs/kubernetes-overview/ingress-loadbalancer
+  
+  See more details at: https://docs.duplocloud.com/docs/kubernetes-overview/ingress-loadbalancer
   """
   
   def __init__(self, duplo: DuploClient):

--- a/src/tests/test_ingress.py
+++ b/src/tests/test_ingress.py
@@ -36,7 +36,7 @@ class TestIngress:
         """Test updating an Ingress resource."""
         r = ingress_resource
         update_body = get_test_data("ingress")
-        response = execute_test(r.update, body=update_body)
+        response = execute_test(r.update, name=self.ingress_name, body=update_body)
         assert response.get("message") and f"Successfully Updated an Ingress '{update_body['name']}'" in response["message"], "Ingress updation failed"
 
     @pytest.mark.integration


### PR DESCRIPTION
## Describe Changes

- Patching support and docs enhancements were added for an Ingress. 
- Follwoing usecases are tested -

```
duploctl ingress create -f src/tests/data/ingress.yaml

duploctl ingress update duploctl-ingress -f src/tests/data/ingress.yaml 
duploctl ingress update duploctl-ingress --replace lbConfig.dnsPrefix test
duploctl ingress update duploctl-ingress --replace rules/0.port 8080
duploctl ingress update duploctl-ingress --remove lbConfig.dnsPrefix
duploctl ingress update duploctl-ingress --remove rules.0
duploctl ingress update duploctl-ingress --add data.ExistingKey
duploctl ingress update duploctl-ingress --add rules/- <json>

duploctl ingress delete duploctl-ingress
```

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30983

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] validated with integration tests.
- [x] Make sure to note changes in Changelog.
