### PR TITLE
DUPLO-31078: IssueFix bulk_update_image was not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Patching support and docs enhancements were added for the ConfigMap resource.
+- bulk_update_image to handle serviceimage input as a list of [name, image] pairs instead of a dict.
 
 ## [0.2.47] - 2025-04-07
 

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -467,7 +467,7 @@ class DuploService(DuploTenantResourceV2):
     """
     payload = []
     wait_list = []
-    for name, image in serviceimage.items():
+    for name, image in serviceimage:
       service = self.find(name)
       payload_item = {
           "Name": name,


### PR DESCRIPTION
## Describe Changes

While executing bulk_update_image duploctl getting an error: An unexpected error occurred: 'list' object has no attribute 'items'. Issue was `serviceimage` arg is a list of lists, not a dictionary so calling .items() on it results in an error.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-31078

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Make sure to note changes in Changelog
