### PR TITLE
DUPLO-30986 added patch support for k8s job resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Patching support and docs enhancements were added for the ConfigMap resource.
 - Patching support and docs enhancements were added for the K8S Secret resource.
+- Patching support and docs enhancements were added for the K8S Jobs resource.
 - bulk_update_image to handle serviceimage input as a list of [name, image] pairs instead of a dict.
 
 ## [0.2.47] - 2025-04-07

--- a/src/duplo_resource/job.py
+++ b/src/duplo_resource/job.py
@@ -157,7 +157,9 @@ class DuploJob(DuploTenantResourceV3):
                       help='Use --suspend-job to pause job execution or --resume-job to continue execution',
                       type=bool,
                       action=argparse.BooleanOptionalAction) = None,
-             ttl_seconds_after_finished: args.MAX = None,
+             ttl_seconds_after_finished: Arg('ttl-seconds', '--ttl-seconds-after-finished',
+                      help='Time in seconds to automatically delete job after it finishes',
+                      type=int) = None,
              dryrun: args.DRYRUN = False) -> dict:
     """Update a Job resource.
 
@@ -186,7 +188,7 @@ class DuploJob(DuploTenantResourceV3):
 
     Example: Change TTL after completion
       ```sh
-      duploctl job update <job-name> --max 3600
+      duploctl job update <job-name> --ttl-seconds-after-finished 3600
       ```
 
     Example: Use JSON patches to update fields
@@ -200,7 +202,7 @@ class DuploJob(DuploTenantResourceV3):
         The options are `--add`, `--remove`, `--replace`, `--move`, and `--copy`.
         Then followed by `<path>` and `<value>` for `--add`, `--replace`, and `--test`.
       suspend_job: Use `--suspend-job` to pause job execution or `--resume-job` to continue execution.
-      ttl_seconds_after_finished: Time in seconds to automatically delete job after it finishes (use `--max` flag).
+      ttl_seconds_after_finished: Time in seconds to automatically delete job after it finishes (use `--ttl-seconds-after-finished` flag).
       dryrun (bool, optional): If True, return the modified job without applying changes.
 
     Returns:


### PR DESCRIPTION
## Describe Changes

Added patch support for k8s job resource.
Following use cases were tested
```
duploctl job create -f src/tests/data/job.yaml
duploctl job update duploctl --suspend-job
duploctl job update duploctl --resume-job
duploctl job update duploctl --add /spec/suspend true
duploctl job update duploctl --add /spec/suspend false
duploctl job update duploctl --add /spec/ttlSecondsAfterFinished 3000
duploctl job update duploctl --ttl-seconds-after-finished 3600

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-30986

## PR Review Checklist  

- [*] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [*] Make sure to note changes in Changelog
