### PR TITLE
DUPLO-31178: Add wait flag as global parameter to duplo client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added DuploStillWaiting class to reflect scenarios where a command waits too long for a resource operation to complete.
 - Added integration tests for k8 Secret resource.
-- Added a timeout parameter to the service update_image to control operation duration.
+- Added wait flag as an argument to DuploClient.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added fields to the ecs service update task def to replace a bug 
+- Added a timeout parameter to the service update_image to control operation duration.
 
 ## [0.2.49] - 2025-04-21
 

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -62,8 +62,7 @@ class DuploAsg(DuploTenantResourceV2):
     
   @Command()
   def create(self,
-             body: args.BODY,
-             wait: args.WAIT=False) -> dict:
+             body: args.BODY) -> dict:
     """Create an ASG.
 
     Creates a new Auto Scaling Group with the specified configuration. The ASG will manage
@@ -103,7 +102,7 @@ class DuploAsg(DuploTenantResourceV2):
     res = self.duplo.post(f"subscriptions/{tenant_id}/UpdateTenantAsgProfile", body)
     def wait_check():
       return self.find(name)
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check)
     return {
       "message": f"Successfully created asg '{body['FriendlyName']}'",

--- a/src/duplo_resource/aws_secret.py
+++ b/src/duplo_resource/aws_secret.py
@@ -18,8 +18,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
              name: args.NAME=None,
              body: args.BODY=None,
              value: args.PARAM_CONTENT=None,
-             dryrun: args.DRYRUN=False,
-             wait: args.WAIT=False) -> dict:
+             dryrun: args.DRYRUN=False) -> dict:
     """Create an AWS Secretmanager Secret
     Usage: cli usage
       ```sh
@@ -56,7 +55,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
     if dryrun:
       return body
     else:
-      return super().create(body, wait=wait)
+      return super().create(body=body)
 
   @Command()
   #Implement find with opt-in option to display sensitive data. 
@@ -95,8 +94,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
   def update(self, 
              name: args.NAME=None,
              value: args.PARAM_CONTENT=None,
-             dryrun: args.DRYRUN=False,
-             wait: args.WAIT=False) -> dict:
+             dryrun: args.DRYRUN=False) -> dict:
     """Update an AWS Secretmanager secret.
     Usage: cli usage
       ```sh
@@ -115,6 +113,8 @@ class DuploAwsSecret(DuploTenantResourceV3):
     """
     body=self.find(name)
     body['SecretString'] = value
+    if dryrun:
+      return body
     return super().update(name=name, body=body)
 
   @Command()

--- a/src/duplo_resource/cloudfront.py
+++ b/src/duplo_resource/cloudfront.py
@@ -6,14 +6,18 @@ import duplocloud.args as args
 
 @Resource("cloudfront")
 class CloudFront(DuploTenantResourceV3):
+    """Manage CloudFront Distributions
+
+    Configuring a CloudFront distributions in DuploCloud are content delivery network (CDN) configurations that
+    help you improve the performance of your web applications.
+
+    See more details at: https://docs.duplocloud.com/docs/overview/aws-services/cloudfront
+    """
 
     def __init__(self, duplo: DuploClient):
       super().__init__(duplo, "aws/cloudFrontDistribution")
 
     def wait_check(self, distribution_id):
-      """
-      Waits for the CloudFront distribution to be in 'Deployed' status.
-      """
       status_response = self.find(distribution_id)
       status = status_response.get("Distribution", {}).get("Status", "Unknown").lower()
       if status == "deployed":
@@ -25,38 +29,50 @@ class CloudFront(DuploTenantResourceV3):
 
     @Command()
     def find(self, distribution_id: args.DISTRIBUTION_ID):
-      """
+      """Find a CloudFront distribution.
+
       Find a CloudFront distribution by its distribution ID.
+
       Usage:
         ```sh
         duploctl cloudfront find <distribution_id>
         ```
+
       Args:
-          distribution_id (str): The CloudFront distribution ID.
+        distribution_id: The CloudFront distribution ID.
+
       Returns:
-          dict: The service object.
+        dict: The service object.
       """
       response = self.duplo.get(self.endpoint(name=distribution_id))
       response.raise_for_status()
       return response.json()
 
     @Command()
-    def create(self, body: args.BODY, wait: args.WAIT = False):
-      """
-      Create a CloudFront distribution.
+    def create(self, body: args.BODY):
+      """Create a CloudFront distribution.
+
+      Creates a new CloudFront distribution with the specified configuration.
+
       Usage: Basic CLI Use
         ```sh
-        duploctl cloudfront create --file cloudfront.yaml
+        duploctl cloudfront create -f cloudfront.yaml
         ```
-      Contents of the `cloudfront.yaml` file
+
+      Example cloudfront.yaml:
         ```yaml
         --8<-- "src/tests/data/cloudfront-create.yaml"
         ```
+
       Args:
-          body: The request payload for CloudFront creation.
-          wait: Whether to wait until the distribution is deployed.
+        body: The distribution configuration including origins, behaviors, and other settings.
+
       Returns:
-          dict: The created distribution details.
+        dict: The created distribution details including the distribution ID.
+
+      Raises:
+        DuploError: If the distribution could not be created or the configuration is invalid.
+        DuploFailedResource: If the distribution creation process fails.
       """
       data = None
       try:
@@ -66,29 +82,37 @@ class CloudFront(DuploTenantResourceV3):
         distribution_id = data.get("Id") or data.get("Distribution", {}).get("Id")
         if not distribution_id:
           raise ValueError("Failed to retrieve CloudFront Distribution ID from response.")
-        if wait:
+        if self.duplo.wait:
           self.wait(lambda: self.wait_check(distribution_id) is not None, 1200)
         return data
       except Exception as e:
         raise DuploError(f"Failed to create CloudFront distribution: {e}")
 
     @Command()
-    def update(self, body: args.BODY, wait: args.WAIT=False):
-      """
-      Update a CloudFront distribution.
+    def update(self, body: args.BODY):
+      """Update a CloudFront distribution.
+
+      Updates an existing CloudFront distribution with new configuration settings.
+
       Usage: Basic CLI Use
         ```sh
-        duploctl cloudfront update --file cloudfront.yaml
+        duploctl cloudfront update -f cloudfront.yaml
         ```
-      Contents of the `cloudfront.yaml` file
+
+      Example cloudfront.yaml:
         ```yaml
         --8<-- "src/tests/data/cloudfront-update.yaml"
         ```
+
       Args:
-          body: The request payload for CloudFront updation.
-          wait: Whether to wait until the distribution is deployed.
+        body: The updated distribution configuration.
+
       Returns:
-          dict: The updated distribution details.
+        dict: The updated distribution details.
+
+      Raises:
+        DuploError: If the distribution could not be updated or the configuration is invalid.
+        DuploFailedResource: If the update process fails.
       """
       try:
         response = self.duplo.put(self.endpoint(), body)
@@ -97,64 +121,90 @@ class CloudFront(DuploTenantResourceV3):
         distribution_id = data.get("Id") or data.get("Distribution", {}).get("Id")
         if not distribution_id:
           raise ValueError("Failed to retrieve CloudFront Distribution ID from response.")
-        if wait:
+        if self.duplo.wait:
           self.wait(lambda: self.wait_check(distribution_id) is not None, 1200)
         return data
       except Exception as e:
         raise DuploError(f"Failed to update CloudFront distribution: {e}")
 
     @Command()
-    def disable(self, distribution_id: args.DISTRIBUTION_ID, wait: args.WAIT=False):
-      """
-      Disable a CloudFront distribution.
-      Usage:
-          ```sh
-          duploctl cloudfront disable <distribution_id>
-          ```
+    def disable(self, distribution_id: args.DISTRIBUTION_ID):
+      """Disable a CloudFront distribution.
+
+      Disables content delivery for a CloudFront distribution. When disabled,
+      the distribution will stop serving content but will retain its configuration.
+
+      Usage: Basic CLI Use
+        ```sh
+        duploctl cloudfront disable <distribution-id>
+        ```
+
       Args:
-          distribution_id (str): The ID of the CloudFront distribution to be disabled.
-          wait: Whether to wait for the CloudFront distribution to disable.
+        distribution_id: The ID of the CloudFront distribution to disable.
+
       Returns:
-          dict: The service object.
+        dict: The updated distribution details.
+
+      Raises:
+        DuploError: If the distribution could not be disabled.
+        DuploFailedResource: If the disable process fails.
       """
       body = {"Id":distribution_id,"DistributionConfig":{"Disabled":"true"}}
       response = self.duplo.put(self.endpoint(), body)
-      if wait:
+      if self.duplo.wait:
         self.wait(lambda: self.wait_check(distribution_id) is not None, 1200)
       return response.json()
     
     @Command()
-    def enable(self, distribution_id: args.DISTRIBUTION_ID, wait: args.WAIT=False):
-      """
-      Enable a CloudFront distribution.
-      Usage:
-          ```sh
-          duploctl cloudfront enable <distribution_id>
-          ```
+    def enable(self, distribution_id: args.DISTRIBUTION_ID):
+      """Enable a CloudFront distribution.
+
+      Enables content delivery for a previously disabled CloudFront distribution.
+      When enabled, the distribution will start serving content using its current
+      configuration.
+
+      Usage: Basic CLI Use
+        ```sh
+        duploctl cloudfront enable <distribution-id>
+        ```
+
       Args:
-          distribution_id (str): The ID of the CloudFront distribution to be enabled.
-          wait: Whether to wait for the CloudFront distribution to enable.
+        distribution_id: The ID of the CloudFront distribution to enable.
+
       Returns:
-          dict: The service object.
+        dict: The updated distribution details.
+
+      Raises:
+        DuploError: If the distribution could not be enabled.
+        DuploFailedResource: If the enable process fails.
       """
       body = {"Id":distribution_id,"DistributionConfig":{"Enabled":"true"}}
       response = self.duplo.put(self.endpoint(), body)
-      if wait:
+      if self.duplo.wait:
         self.wait(lambda: self.wait_check(distribution_id) is not None, 1200)
       return response.json()
 
     @Command()
     def delete(self, distribution_id: args.DISTRIBUTION_ID):
-      """
-      Delete a CloudFront distribution.
-      Usage:
-          ```sh
-          duploctl cloudfront delete <distribution_id>
-          ```
+      """Delete a CloudFront distribution.
+
+      Permanently removes a CloudFront distribution. This operation is irreversible
+      and will remove all distribution settings and cached content. The distribution
+      must be disabled before it can be deleted.
+
+      Usage: Basic CLI Use
+        ```sh
+        duploctl cloudfront delete <distribution-id>
+        ```
+
       Args:
-          distribution_id (str): The ID of the CloudFront distribution to delete.
+        distribution_id: The ID of the CloudFront distribution to delete.
+
       Returns:
-          dict: Confirmation message.
+        dict: Success message confirming the deletion.
+
+      Raises:
+        DuploError: If the distribution could not be deleted or is not in a deletable state.
       """
       response = self.duplo.delete(self.endpoint(distribution_id))
       response.raise_for_status()
@@ -162,18 +212,25 @@ class CloudFront(DuploTenantResourceV3):
 
     @Command()
     def get_status(self, distribution_id: args.DISTRIBUTION_ID):
-      """
-      Retrieve the status of a CloudFront distribution by its distribution ID.
-      Usage:
-          ```sh
-          duploctl cloudfront get_status <distribution_id>
-          ```
+      """Get the current status of a CloudFront distribution.
+
+      Retrieves the current deployment status of a CloudFront distribution.
+      The status indicates whether the distribution is deployed, in progress,
+      or in an error state.
+
+      Usage: Basic CLI Use
+        ```sh
+        duploctl cloudfront get-status <distribution-id>
+        ```
+
       Args:
-          distribution_id (str): The CloudFront distribution ID.
+        distribution_id: The ID of the CloudFront distribution to check.
+
       Returns:
-          str: The status of the CloudFront distribution.
+        str: The current status of the distribution (e.g., 'Deployed', 'InProgress').
+
       Raises:
-          DuploError: If the CloudFront distribution could not be found or lacks a status.
+        DuploError: If the distribution could not be found or the status is unavailable.
       """
       response = self.find(distribution_id)
       status = response.get("Distribution", {}).get("Status")

--- a/src/duplo_resource/ecs_service.py
+++ b/src/duplo_resource/ecs_service.py
@@ -158,8 +158,7 @@ class DuploEcsService(DuploTenantResourceV2):
   @Command()
   def update_image(self, 
                    name: args.NAME, 
-                   image: args.IMAGE,
-                   wait: args.WAIT) -> dict:
+                   image: args.IMAGE) -> dict:
     """Update the image for an ECS service.
 
     Example:
@@ -191,7 +190,7 @@ class DuploEcsService(DuploTenantResourceV2):
     # run update here so the errors bubble up correctly
     if svc: 
       self.update_service(svc)
-      if wait:
+      if self.duplo.wait:
         self.wait(lambda: self.wait_on_task(name))
     return {
       "message": msg
@@ -245,8 +244,7 @@ class DuploEcsService(DuploTenantResourceV2):
   @Command()
   def run_task(self, 
                name: args.NAME,
-               replicas: args.REPLICAS,
-               wait: args.WAIT) -> dict:
+               replicas: args.REPLICAS) -> dict:
     """Run a task for an ECS service."
 
     Execute a task based on some definition. 
@@ -266,7 +264,7 @@ class DuploEcsService(DuploTenantResourceV2):
       "Count": replicas if replicas else 1
     }
     res = self.duplo.post(path, body)
-    if wait:
+    if self.duplo.wait:
       self.wait(lambda: self.wait_on_task(name))
     return res.json()
 

--- a/src/duplo_resource/hosts.py
+++ b/src/duplo_resource/hosts.py
@@ -24,8 +24,7 @@ class DuploHosts(DuploTenantResourceV2):
   
   @Command()
   def create(self,
-             body: args.BODY,
-             wait: args.WAIT=False) -> dict:
+             body: args.BODY) -> dict:
     """Create a Host resource.
 
     Creates a new host in the tenant with the specified configuration.
@@ -68,7 +67,7 @@ class DuploHosts(DuploTenantResourceV2):
     if body.get("ImageId", None) is None:
       body["ImageId"] = self.discover_image(body.get("AgentPlatform", 0))
     res = self.duplo.post(self.endpoint("CreateNativeHost"), body)
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check)
     return {
       "message": f"Successfully created host '{body['FriendlyName']}'",
@@ -77,8 +76,7 @@ class DuploHosts(DuploTenantResourceV2):
   
   @Command()
   def delete(self,
-             name: args.NAME,
-             wait: args.WAIT=False) -> dict:
+             name: args.NAME) -> dict:
     """Delete a host.
     
     Terminates a host by its name. This operation is irreversible and will
@@ -114,7 +112,7 @@ class DuploHosts(DuploTenantResourceV2):
           raise DuploFailedResource(f"Host '{name}' failed to delete.")
       if h["Status"] == "shutting-down" or h["Status"] == "running":
         raise DuploStillWaiting(f"Host '{name}' is waiting for termination")
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 500)
     return {
       "message": f"Successfully deleted host '{name}'",
@@ -123,8 +121,7 @@ class DuploHosts(DuploTenantResourceV2):
   
   @Command()
   def stop(self,
-           name: args.NAME,
-           wait: args.WAIT=False) -> dict:
+           name: args.NAME) -> dict:
     """Stop a host.
     
     Stops a running host. The instance can be restarted later using the start
@@ -157,7 +154,7 @@ class DuploHosts(DuploTenantResourceV2):
         if h["Status"] != "stopping":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
         raise DuploStillWaiting(f"Host '{name}' is waiting for status stopped")
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 500)
     return {
       "message": f"Successfully stopped host '{name}'",
@@ -166,8 +163,7 @@ class DuploHosts(DuploTenantResourceV2):
   
   @Command()
   def start(self,
-             name: args.NAME,
-             wait: args.WAIT=False) -> dict:
+             name: args.NAME) -> dict:
     """Start a host.
     
     Starts a stopped host. The instance will retain its configuration and data
@@ -200,7 +196,7 @@ class DuploHosts(DuploTenantResourceV2):
         if h["Status"] != "pending":
           raise DuploFailedResource(f"Host '{name}' failed to stop.")
         raise DuploStillWaiting(f"Host '{name}' is waiting for status running")
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 500)
     return {
       "message": f"Successfully started host '{name}'",

--- a/src/duplo_resource/infrastructure.py
+++ b/src/duplo_resource/infrastructure.py
@@ -32,8 +32,7 @@ class DuploInfrastructure(DuploResource):
   
   @Command()
   def create(self, 
-             body: args.BODY,
-             wait: args.WAIT=False):
+             body: args.BODY):
     """Create a new infrastructure."""
     status = None
     name = body["Name"]
@@ -50,7 +49,7 @@ class DuploInfrastructure(DuploResource):
           raise DuploFailedResource(f"Infrastructure '{name} - {s}'")
         raise DuploStillWaiting(f"Infrastructure '{name}' is waiting for status Complete")
     self.duplo.post("adminproxy/CreateInfrastructureConfig", body)
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 1800, 20)
     return {
       "message": f"Infrastructure '{body['Name']}' created"

--- a/src/duplo_resource/job.py
+++ b/src/duplo_resource/job.py
@@ -15,8 +15,7 @@ class DuploJob(DuploTenantResourceV3):
 
   @Command()  
   def create(self, 
-             body: args.BODY, 
-             wait: args.WAIT = False):
+             body: args.BODY):
     """Create a job."""
     name = self.name_from_body(body)
     a = 0
@@ -69,7 +68,7 @@ class DuploJob(DuploTenantResourceV3):
       # if none have completed, keep waiting
       if not len(cpl) > 0:
         raise DuploStillWaiting(f"Job '{name}' is waiting for 'Complete' condition")
-    super().create(body, wait, wait_check)
+    super().create(body, self.duplo.wait, wait_check)
     return {
       "message": f"Job {name} ran successfully."
     }

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -59,8 +59,7 @@ class DuploLambda(DuploTenantResourceV2):
     
   @Command()
   def create(self, 
-             body: args.BODY,
-             wait: args.WAIT = False) -> dict:
+             body: args.BODY) -> dict:
     """Create a new tenant.
 
     Usage: CLI Usage
@@ -84,7 +83,7 @@ class DuploLambda(DuploTenantResourceV2):
       self.find(name)
     tenant_id = self.tenant["TenantId"]
     self.duplo.post(f"subscriptions/{tenant_id}/CreateLambdaFunction", body)
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 400)
     return {
       "message": f"Lambda {body['FunctionName']} created"

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -14,8 +14,7 @@ class DuploRDS(DuploTenantResourceV3):
 
   @Command()
   def create(self,
-             body: args.BODY,
-             wait: args.WAIT=False):
+             body: args.BODY):
     """Create a DB instance.
     
     Args:
@@ -32,7 +31,7 @@ class DuploRDS(DuploTenantResourceV3):
         self.duplo.logger.warn(f"DB instance {name} is {status}")
       if status != "available":
         raise DuploStillWaiting(f"DB instance '{name}' is waiting for status 'available'")
-    super().create(body, wait, wait_check)
+    super().create(body, self.duplo.wait, wait_check)
 
   @Command()
   def find_cluster(self,
@@ -51,15 +50,14 @@ class DuploRDS(DuploTenantResourceV3):
   
   @Command()
   def stop(self,
-           name: args.NAME,
-           wait: args.WAIT=False):
+           name: args.NAME):
     """Stop a DB instance."""
     def wait_check():
       i = self.find(name)
       if i["InstanceStatus"] in ["stopping","available"]:
         raise DuploStillWaiting(f"DB instance {name} is still stopping")
     self.duplo.post(self.endpoint(name, "stop"))
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 1800, 10)
     return {
       "message": "DB instance stopped"
@@ -67,15 +65,14 @@ class DuploRDS(DuploTenantResourceV3):
   
   @Command()
   def start(self,
-           name: args.NAME,
-           wait: args.WAIT=False):
+           name: args.NAME):
     """Start a DB instance."""
     def wait_check():
       i = self.find(name)
       if i["InstanceStatus"] in ["starting"]:
         raise DuploStillWaiting(f"DB instance {name} is still starting")
     self.duplo.post(self.endpoint(name, "start"))
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 1800, 10)
     return {
       "message": "DB instance started"
@@ -83,8 +80,7 @@ class DuploRDS(DuploTenantResourceV3):
   
   @Command()
   def reboot(self,
-             name: args.NAME,
-             wait: args.WAIT=False):
+             name: args.NAME):
     """Reboot a DB instance."""
     rebooting = False
     def wait_check():
@@ -97,7 +93,7 @@ class DuploRDS(DuploTenantResourceV3):
       raise DuploStillWaiting(f"DB instance {name} is still rebooting")
     # Reboot the instance
     self.duplo.post(self.endpoint(name, "reboot"))
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check, 1800, 10)
     return {
       "message": "DB instance rebooted"

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -226,7 +226,8 @@ class DuploService(DuploTenantResourceV2):
                    image: args.IMAGE = None,
                    container_image: args.CONTAINER_IMAGE = None,
                    init_container_image: args.INIT_CONTAINER_IMAGE = None,
-                   wait: args.WAIT = False) -> dict:
+                   wait: args.WAIT = False,
+                   wait_timeout: args.WAIT_TIMEOUT = 400) -> dict:
     """Update the image of a service.
 
     Usage: Basic CLI Use
@@ -293,7 +294,7 @@ class DuploService(DuploTenantResourceV2):
     self.duplo.post(self.endpoint("ReplicationControllerChange"), data)
 
     if wait:
-      self.wait(service, data)
+      self.wait(service, data, wait_timeout)
 
     response_message = "Successfully updated image for service."
     if updated_containers:
@@ -666,7 +667,7 @@ class DuploService(DuploTenantResourceV2):
     else:
       return body.get("DockerImage", body.get("Image", None))
 
-  def wait(self, old, updates):
+  def wait(self, old, updates, wait_timeout):
     """Wait for a service to update."""
     name = old["Name"]
     cloud = old["Template"]["Cloud"]
@@ -740,7 +741,7 @@ class DuploService(DuploTenantResourceV2):
         raise DuploError(f"Service {name} waiting for pods {running}/{replicas}", 400)
       
     # send to the base class to do the waiting
-    super().wait(wait_check, 400, 11)
+    super().wait(wait_check, wait_timeout, 11)
 
   def name_from_body(self, body):
     return body["Name"]

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -225,9 +225,7 @@ class DuploService(DuploTenantResourceV2):
                    name: args.NAME, 
                    image: args.IMAGE = None,
                    container_image: args.CONTAINER_IMAGE = None,
-                   init_container_image: args.INIT_CONTAINER_IMAGE = None,
-                   wait: args.WAIT = False,
-                   wait_timeout: args.WAIT_TIMEOUT = 400) -> dict:
+                   init_container_image: args.INIT_CONTAINER_IMAGE = None) -> dict:
     """Update the image of a service.
 
     Usage: Basic CLI Use
@@ -293,8 +291,8 @@ class DuploService(DuploTenantResourceV2):
 
     self.duplo.post(self.endpoint("ReplicationControllerChange"), data)
 
-    if wait:
-      self.wait(service, data, wait_timeout)
+    if self.duplo.wait:
+      self.wait(service, data)
 
     response_message = "Successfully updated image for service."
     if updated_containers:
@@ -393,8 +391,7 @@ class DuploService(DuploTenantResourceV2):
                  name: args.NAME,
                  setvar: args.SETVAR,
                  strategy: args.STRATEGY,
-                 deletevar: args.DELETEVAR,
-                 wait: args.WAIT = False):    
+                 deletevar: args.DELETEVAR):    
   
     """Update the pod labels of a service. If service has no pod labels set, use -strat replace to set new values.
     Usage: Basic CLI Use
@@ -667,7 +664,7 @@ class DuploService(DuploTenantResourceV2):
     else:
       return body.get("DockerImage", body.get("Image", None))
 
-  def wait(self, old, updates, wait_timeout):
+  def wait(self, old, updates):
     """Wait for a service to update."""
     name = old["Name"]
     cloud = old["Template"]["Cloud"]
@@ -741,7 +738,7 @@ class DuploService(DuploTenantResourceV2):
         raise DuploStillWaiting(f"Service {name} waiting for pods {running}/{replicas}")
       
     # send to the base class to do the waiting
-    super().wait(wait_check, wait_timeout, 11)
+    super().wait(wait_check, 3600, 11)
 
   def name_from_body(self, body):
     return body["Name"]

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -391,7 +391,8 @@ class DuploService(DuploTenantResourceV2):
                  name: args.NAME,
                  setvar: args.SETVAR,
                  strategy: args.STRATEGY,
-                 deletevar: args.DELETEVAR):    
+                 deletevar: args.DELETEVAR,
+                 wait: args.WAIT = False):
   
     """Update the pod labels of a service. If service has no pod labels set, use -strat replace to set new values.
     Usage: Basic CLI Use

--- a/src/duplo_resource/ssm_param.py
+++ b/src/duplo_resource/ssm_param.py
@@ -19,8 +19,7 @@ class DuploParam(DuploTenantResourceV3):
              body: args.BODY=None,
              paramtype: args.SSM_PARAM_TYPE=None,
              value: args.PARAM_CONTENT=None,
-             dryrun: args.DRYRUN=False,
-             wait: args.WAIT=False) -> dict:
+             dryrun: args.DRYRUN=False) -> dict:
     """Create an SSM Parameter
     Usage: cli usage
       ```sh
@@ -61,7 +60,7 @@ class DuploParam(DuploTenantResourceV3):
     if dryrun:
       return body
     else:
-      return super().create(body, wait=wait)
+      return super().create(body, wait=self.duplo.wait)
 
   @Command()
   #Implement find with opt-in option to display sensitive data for secureString params. 
@@ -102,8 +101,7 @@ class DuploParam(DuploTenantResourceV3):
              name: args.NAME=None,
              strategy: args.STRATEGY='merge',
              value: args.PARAM_CONTENT=None,
-             dryrun: args.DRYRUN=False,
-             wait: args.WAIT=False) -> dict:
+             dryrun: args.DRYRUN=False) -> dict:
     """Update an SSM Parameter.
     Usage: cli usage
       ```sh

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -125,8 +125,7 @@ class DuploTenant(DuploResource):
   
   @Command()
   def create(self, 
-             body: args.BODY,
-             wait: args.WAIT=False) -> dict:
+             body: args.BODY) -> dict:
     """Create Tenant.
     
     Create a new tenant with a new body for a tenant. 
@@ -161,7 +160,7 @@ class DuploTenant(DuploResource):
     self.duplo.post("admin/AddTenant", body)
     def wait_check():
       self.find(name)
-    if wait:
+    if self.duplo.wait:
       self.wait(wait_check)
     return {
       "message": f"Tenant '{name}' created"
@@ -454,7 +453,6 @@ class DuploTenant(DuploResource):
   @Command()
   def start(self, 
             name: args.NAME = None, 
-            wait: args.WAIT=False, 
             exclude: args.EXCLUDE=None) -> dict:
     """Start Tenant All Resources
 
@@ -502,15 +500,14 @@ class DuploTenant(DuploResource):
       for item in service.list():
         service_name = service.name_from_body(item)
         if service_name not in service_types[service_type]:
-          service.start(service_name, wait)
+          service.start(service_name, self.duplo.wait)
     return {
       "message": "Successfully started all resources for tenant"
     }
 
   @Command()
   def stop(self, 
-           name: args.NAME = None, 
-           wait: args.WAIT=False, 
+           name: args.NAME = None,
            exclude: args.EXCLUDE=None) -> dict:
     """Stop Tenant All Resources
 
@@ -558,7 +555,7 @@ class DuploTenant(DuploResource):
       for item in service.list():
         service_name = service.name_from_body(item)
         if service_name not in service_types[service_type]:
-          service.stop(service_name, wait)
+          service.stop(service_name, self.duplo.wait)
     return {
       "message": "Successfully stopped all resources for tenant"
     }

--- a/src/duplocloud/args.py
+++ b/src/duplocloud/args.py
@@ -260,6 +260,10 @@ WAIT = Arg("wait", "-w",
            type=bool,
            action='store_true')
 
+WAIT_TIMEOUT = Arg("wait-timeout", "--wait-timeout",
+               help = 'Wait timeout for the operation to complete',
+               type = int)
+
 ALL = Arg("all", "--all",
            help='Boolean flag to select all. Defaults to False.',
            type=bool,

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -57,7 +57,8 @@ class DuploClient():
                isadmin: args.ISADMIN=False,
                query: args.QUERY=None,
                output: args.OUTPUT="json",
-               loglevel: args.LOGLEVEL="WARN"):
+               loglevel: args.LOGLEVEL="WARN",
+               wait: args.WAIT=False):
     """DuploClient Constructor
     
     Creates an instance of a duplocloud client configured for a certain portal. All of the arguments are optional and can be set in the environment or in the config file. The types of each ofthe arguments are annotated types that are used by argparse to create the command line arguments.
@@ -115,6 +116,7 @@ class DuploClient():
     self.__ttl_cache = TTLCache(maxsize=128, ttl=10)
     self.loglevel = loglevel
     self.logger = self.logger_for()
+    self.wait = wait
 
   @staticmethod
   def from_env():

--- a/src/duplocloud/resource.py
+++ b/src/duplocloud/resource.py
@@ -41,8 +41,7 @@ class DuploResource():
       return command(**pargs)
     return wrapped
   
-  def wait(self, wait_check: callable, timeout: int=None, poll: int=10):
-    timeout = timeout or self.duplo.timeout
+  def wait(self, wait_check: callable, timeout: int=3600, poll: int=10):
     exp = math.ceil(timeout / poll)
     for _ in range(exp):
       try:
@@ -58,7 +57,7 @@ class DuploResource():
         raise e
     else:
       raise DuploStillWaiting("Timed out waiting")
-    
+
 class DuploResourceV2(DuploResource):
 
   def name_from_body(self, body):

--- a/src/tests/test_asg.py
+++ b/src/tests/test_asg.py
@@ -7,6 +7,7 @@ from .conftest import get_test_data
 def asg_resource(duplo):
     """Fixture to load the ASG resource and define ASG name."""
     resource = duplo.load("asg")
+    resource.duplo.wait = True
     tenant = resource.tenant["AccountName"]
     asg_name = f"duploservices-{tenant}-duploctl"
     return resource, asg_name
@@ -26,7 +27,7 @@ class TestAsg:
     def test_create_asg(self, asg_resource):
         r, asg_name = asg_resource
         body = get_test_data("asg")
-        response = execute_test(r.create, body=body, wait=True)
+        response = execute_test(r.create, body=body)
         assert response["data"] == asg_name
         time.sleep(60)
 

--- a/src/tests/test_aws_secret.py
+++ b/src/tests/test_aws_secret.py
@@ -6,6 +6,7 @@ from duplocloud.errors import DuploError
 def aws_secret_resource(duplo):
     """Fixture to load the AWS Secret resource and define the secret name."""
     resource = duplo.load("aws_secret")
+    resource.duplo.wait = True
     tenant = resource.tenant["AccountName"]
     secret_name = f"duploservices-{tenant}-secret"
     return resource, secret_name
@@ -26,7 +27,7 @@ class TestAwsSecret:
         """Test creating an AWS secret."""
         r, secret_name = aws_secret_resource
         body = {"Name": secret_name, "SecretString": '{"foo": "bar"}'}
-        execute_test(r.create, name=secret_name, body=body, wait=True)
+        execute_test(r.create, name=secret_name, body=body)
         time.sleep(10)
 
     @pytest.mark.integration

--- a/src/tests/test_cloudfront.py
+++ b/src/tests/test_cloudfront.py
@@ -7,6 +7,7 @@ from .conftest import get_test_data
 def cloudfront_resource(duplo, request):
     """Fixture to load the CloudFront resource and ensure CloudFront ID persists across tests."""
     resource = duplo.load("cloudfront")
+    resource.duplo.wait = True
     tenant = resource.tenant["AccountName"]
     request.cls.cloudfront_id = None
     return resource
@@ -28,7 +29,7 @@ class TestCloudFront:
         """Test creating a CloudFront distribution and store ID at class level."""
         r = cloudfront_resource
         body = get_test_data("cloudfront-create")
-        response = execute_test(r.create, body=body, wait=True)
+        response = execute_test(r.create, body=body)
         status_response = execute_test(r.get_status, distribution_id=response["Id"])
         assert status_response == "Deployed", "CloudFront distribution not deployed"
         request.cls.cloudfront_id = response["Id"]
@@ -45,7 +46,7 @@ class TestCloudFront:
         cloudfront = execute_test(r.find, distribution_id=self.cloudfront_id)
         update_body["Id"] = self.cloudfront_id
         update_body["DistributionConfig"]["CallerReference"] = cloudfront["Distribution"]["DistributionConfig"]["CallerReference"]
-        response = execute_test(r.update, body=update_body, wait=True)
+        response = execute_test(r.update, body=update_body)
         status_response = execute_test(r.get_status, distribution_id=response["Id"])
         assert status_response == "Deployed", "CloudFront distribution not deployed after update"
 
@@ -66,7 +67,7 @@ class TestCloudFront:
         """Test disabling a CloudFront distribution."""
         r = cloudfront_resource
         assert self.cloudfront_id is not None, "CloudFront ID not found!"
-        execute_test(r.disable, distribution_id=self.cloudfront_id, wait=True)
+        execute_test(r.disable, distribution_id=self.cloudfront_id)
         status_response = execute_test(r.get_status, distribution_id=self.cloudfront_id)
         assert status_response == "Deployed", "CloudFront distribution was not disabled"
 
@@ -77,10 +78,10 @@ class TestCloudFront:
         """Test enabling a CloudFront distribution."""
         r = cloudfront_resource
         assert self.cloudfront_id is not None, "CloudFront ID not found!"
-        execute_test(r.enable, distribution_id=self.cloudfront_id, wait=True)
+        execute_test(r.enable, distribution_id=self.cloudfront_id)
         status_response = execute_test(r.get_status, distribution_id=self.cloudfront_id)
         assert status_response == "Deployed", "CloudFront distribution was not enabled"
-        execute_test(r.disable, distribution_id=self.cloudfront_id, wait=True)
+        execute_test(r.disable, distribution_id=self.cloudfront_id)
 
     @pytest.mark.integration
     @pytest.mark.dependency(depends=["create_cloudfront"], scope="session")

--- a/src/tests/test_hosts.py
+++ b/src/tests/test_hosts.py
@@ -7,6 +7,7 @@ from .conftest import get_test_data
 def hosts_resource(duplo, request):
     """Fixture to load the Hosts resource and define host name."""
     resource = duplo.load("hosts")
+    resource.duplo.wait = True
     tenant = resource.tenant["AccountName"]
     request.cls.host_name = f"duploservices-{tenant}-duplohost"
     return resource
@@ -25,7 +26,7 @@ class TestHosts:
     @pytest.mark.order(5)
     def test_create_host(self, hosts_resource):
         body = get_test_data("hosts")
-        response = execute_test(hosts_resource.create, body, wait=True)
+        response = execute_test(hosts_resource.create, body)
         assert "Successfully created host" in response["message"]
         time.sleep(60)
 
@@ -41,7 +42,7 @@ class TestHosts:
     @pytest.mark.dependency(depends=["create_host"], scope="session")
     @pytest.mark.order(7)
     def test_stop_host(self, hosts_resource):
-        response = execute_test(hosts_resource.stop, self.host_name, wait=True)
+        response = execute_test(hosts_resource.stop, self.host_name)
         assert "Successfully stopped host" in response["message"]
         host = execute_test(hosts_resource.find, self.host_name)
         assert host["Status"] == "stopped"
@@ -50,7 +51,7 @@ class TestHosts:
     @pytest.mark.dependency(depends=["create_host"], scope="session")
     @pytest.mark.order(8)
     def test_start_host(self, hosts_resource):
-        response = execute_test(hosts_resource.start, self.host_name, wait=True)
+        response = execute_test(hosts_resource.start, self.host_name)
         assert "Successfully started host" in response["message"]
         host = execute_test(hosts_resource.find, self.host_name)
         assert host["Status"] == "running"
@@ -69,5 +70,5 @@ class TestHosts:
     @pytest.mark.dependency(depends=["create_host"], scope="session")
     @pytest.mark.order(997)
     def test_delete_host(self, hosts_resource):
-        response = execute_test(hosts_resource.delete, self.host_name, wait=True)
+        response = execute_test(hosts_resource.delete, self.host_name)
         assert "Successfully deleted host" in response["message"]

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -9,7 +9,17 @@ def test_create_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploService(mock_client)
     body = {"Name": "test-service", "Image": "nginx:latest"}
-    
+    # Mock the find method to return service details
+    mock_service_details = {
+        "Name": "test-service",
+        "Image": "nginx:latest",
+        "Replicaset": "rs-123"
+    }
+    mocker.patch.object(service, 'find', return_value=mock_service_details)
+    # Mock the wait method
+    mocker.patch.object(service, 'wait')
+    # Enable wait flag
+    mock_client.wait = True
     service.create(body)
     mock_client.post.assert_called_once_with(ANY, body)
 
@@ -17,7 +27,6 @@ def test_create_service(mocker):
 def test_delete_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploService(mock_client)
-    
     service.delete("test-service")
     mock_client.post.assert_called_once_with(ANY, {"Name": "test-service", "State": "delete"})
 
@@ -25,7 +34,16 @@ def test_delete_service(mocker):
 def test_restart_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploService(mock_client)
-    
+    # Mock the find method to return service details
+    mock_service_details = {
+        "Name": "test-service",
+        "Status": "Running"
+    }
+    mocker.patch.object(service, 'find', return_value=mock_service_details)
+    # Mock the wait method
+    mocker.patch.object(service, 'wait')
+    # Enable wait flag
+    mock_client.wait = True
     service.restart("test-service")
     mock_client.post.assert_called_once_with(ANY)
 
@@ -33,7 +51,16 @@ def test_restart_service(mocker):
 def test_stop_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploService(mock_client)
-    
+    # Mock the find method to return service details
+    mock_service_details = {
+        "Name": "test-service",
+        "Status": "Running"
+    }
+    mocker.patch.object(service, 'find', return_value=mock_service_details)
+    # Mock the wait method
+    mocker.patch.object(service, 'wait')
+    # Enable wait flag
+    mock_client.wait = True
     service.stop("test-service")
     mock_client.post.assert_called_once_with(ANY)
 
@@ -41,6 +68,15 @@ def test_stop_service(mocker):
 def test_start_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploService(mock_client)
-    
+    # Mock the find method to return service details
+    mock_service_details = {
+        "Name": "test-service",
+        "Status": "Stopped"
+    }
+    mocker.patch.object(service, 'find', return_value=mock_service_details)
+    # Mock the wait method
+    mocker.patch.object(service, 'wait')
+    # Enable wait flag
+    mock_client.wait = True
     service.start("test-service")
     mock_client.post.assert_called_once_with(ANY)

--- a/src/tests/test_service_update_image.py
+++ b/src/tests/test_service_update_image.py
@@ -425,5 +425,6 @@ def test_post_data(service_definition, kwargs, post_data, mocker):
   )
   post_data = post_data
   mock_client = mocker.MagicMock()
+  mock_client.wait = False
   DuploService(mock_client).update_image(**kwargs)
   mock_client.post.assert_called_once_with(ANY, post_data)

--- a/src/tests/test_service_update_image.py
+++ b/src/tests/test_service_update_image.py
@@ -427,23 +427,3 @@ def test_post_data(service_definition, kwargs, post_data, mocker):
   mock_client = mocker.MagicMock()
   DuploService(mock_client).update_image(**kwargs)
   mock_client.post.assert_called_once_with(ANY, post_data)
-
-@pytest.mark.unit
-def test_wait_functionality(mocker):
-    service_definition = {'Template': {}}
-    mock_client = mocker.MagicMock()
-    service = DuploService(mock_client)
-    mocker.patch('duplo_resource.service.DuploService.find',
-                 mocker.MagicMock(return_value=service_definition))
-    mock_wait = mocker.patch('duplo_resource.service.DuploService.wait')
-    # Test wait functionality
-    service.update_image(
-        name='widget',
-        image='new:v2',
-        wait=True,
-        wait_timeout=300
-    )
-    mock_wait.assert_called_once()
-    args = mock_wait.call_args[0]
-    assert args[0] == service_definition
-    assert args[2] == 300

--- a/src/tests/test_service_update_image.py
+++ b/src/tests/test_service_update_image.py
@@ -427,3 +427,23 @@ def test_post_data(service_definition, kwargs, post_data, mocker):
   mock_client = mocker.MagicMock()
   DuploService(mock_client).update_image(**kwargs)
   mock_client.post.assert_called_once_with(ANY, post_data)
+
+@pytest.mark.unit
+def test_wait_functionality(mocker):
+    service_definition = {'Template': {}}
+    mock_client = mocker.MagicMock()
+    service = DuploService(mock_client)
+    mocker.patch('duplo_resource.service.DuploService.find',
+                 mocker.MagicMock(return_value=service_definition))
+    mock_wait = mocker.patch('duplo_resource.service.DuploService.wait')
+    # Test wait functionality
+    service.update_image(
+        name='widget',
+        image='new:v2',
+        wait=True,
+        wait_timeout=300
+    )
+    mock_wait.assert_called_once()
+    args = mock_wait.call_args[0]
+    assert args[0] == service_definition
+    assert args[2] == 300


### PR DESCRIPTION
## Describe Changes

Added a timeout parameter to the service update_image to control operation duration.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-31178

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
