### PR TITLE
DUPLO-34392: Updated duploctl jit update_aws_config to overwrite existing profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Updated jit update_aws_config to always overwrite existing profile entries with new values instead of skipping them.
+
 ## [0.3.0] - 2025-07-15
 
 ### Added 

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -194,22 +194,17 @@ class DuploJit(DuploResource):
     config = os.environ.get("AWS_CONFIG_FILE", f"{Path.home()}/.aws/config")
     cp = configparser.ConfigParser()
     cp.read(config)
-
-    # If name is not provided, set default profile name to "duplo"
     name = name or "duplo"
-
     prf = f'profile {name}'
-    msg = f"aws profile named {name} already exists in {config}"
-    try:
-      cp[prf]
-    except KeyError:
-      cmd = self.duplo.build_command("duploctl", "jit", "aws")
+    cmd = self.duplo.build_command("duploctl", "jit", "aws")
+    is_new_profile = not cp.has_section(prf)
+    if is_new_profile:
       cp.add_section(prf)
-      cp.set(prf, 'region', os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
-      cp.set(prf, 'credential_process', " ".join(cmd))
-      with open(config, 'w') as configfile:
-        cp.write(configfile)
-      msg = f"aws profile named {name} was successfully added to {config}"
+    cp.set(prf, 'region', os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+    cp.set(prf, 'credential_process', " ".join(cmd))
+    with open(config, 'w') as configfile:
+      cp.write(configfile)
+    msg = f"aws profile named {name} was successfully {'added' if is_new_profile else 'updated'} in {config}"
     return {"message": msg}
 
   @Command()

--- a/src/tests/test_jit.py
+++ b/src/tests/test_jit.py
@@ -1,3 +1,5 @@
+import configparser
+import os
 import pytest
 from duplocloud.client import DuploClient
 from duplocloud.errors import DuploError
@@ -48,5 +50,21 @@ class TestJIT:
     except DuploError as e:
       pytest.fail(f"Failed to get admin k8s credentials: {e}")
   
-  
-
+  @pytest.mark.integration
+  @pytest.mark.order(10)
+  def test_update_aws_config(self, duplo: DuploClient, tmp_path):
+    config_file = tmp_path / "config"
+    os.environ["AWS_CONFIG_FILE"] = str(config_file)
+    r = duplo.load("jit")
+    profile_name = "test_profile"
+    result = r.update_aws_config(profile_name)
+    assert "added" in result["message"].lower()
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    profile_section = f"profile {profile_name}"
+    assert config.has_section(profile_section)
+    assert config.get(profile_section, "region") == os.getenv("AWS_DEFAULT_REGION", "us-west-2")
+    assert "duploctl jit aws" in config.get(profile_section, "credential_process")
+    result = r.update_aws_config(profile_name)
+    assert "updated" in result["message"].lower()
+    os.environ.pop("AWS_CONFIG_FILE", None)


### PR DESCRIPTION
### **User description**
## Describe Changes

Updated the logic to always overwrite the specified AWS profile in the config file with new values, ensuring consistent configuration updates instead of skipping existing profiles.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-34392

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Enhancement


___

### **Description**
- Modified AWS profile configuration to always overwrite existing profiles

- Added comprehensive test coverage for profile creation and updates

- Updated changelog to document the behavior change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AWS Config Check"] --> B["Profile Exists?"]
  B --> C["Create/Update Profile"]
  C --> D["Write Config File"]
  D --> E["Return Success Message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Refactor AWS profile update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/jit.py

<ul><li>Removed try-catch logic that skipped existing profiles<br> <li> Added profile existence check using <code>has_section()</code><br> <li> Always write profile configuration regardless of existence<br> <li> Updated return message to indicate "added" or "updated"</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/164/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jit.py</strong><dd><code>Add AWS config update tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_jit.py

<ul><li>Added imports for <code>configparser</code> and <code>os</code><br> <li> Created comprehensive test for <code>update_aws_config</code> method<br> <li> Tests both profile creation and update scenarios<br> <li> Verifies profile configuration and return messages</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/164/files#diff-147482cb3678a8293a65528253909fb168a7b7b21108bd1312cbd59220f23c88">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document profile overwrite feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the profile overwrite behavior change<br> <li> Placed under "Added" section in unreleased changes</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/164/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

