### PR TITLE
Revert "updated jit update_aws_config"

### DIFF
--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -194,18 +194,22 @@ class DuploJit(DuploResource):
     config = os.environ.get("AWS_CONFIG_FILE", f"{Path.home()}/.aws/config")
     cp = configparser.ConfigParser()
     cp.read(config)
+
+    # If name is not provided, set default profile name to "duplo"
     name = name or "duplo"
+
     prf = f'profile {name}'
-    cmd = self.duplo.build_command("duploctl", "jit", "aws")
-    is_new_profile = not cp.has_section(prf)
-    if is_new_profile:
+    msg = f"aws profile named {name} already exists in {config}"
+    try:
+      cp[prf]
+    except KeyError:
+      cmd = self.duplo.build_command("duploctl", "jit", "aws")
       cp.add_section(prf)
-    cp.set(prf, 'region', os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
-    cp.set(prf, 'credential_process', " ".join(cmd))
-    os.makedirs(os.path.dirname(config), exist_ok=True)
-    with open(config, 'w') as configfile:
-      cp.write(configfile)
-    msg = f"aws profile named {name} was successfully {'added' if is_new_profile else 'updated'} in {config}"
+      cp.set(prf, 'region', os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+      cp.set(prf, 'credential_process', " ".join(cmd))
+      with open(config, 'w') as configfile:
+        cp.write(configfile)
+      msg = f"aws profile named {name} was successfully added to {config}"
     return {"message": msg}
 
   @Command()

--- a/src/tests/test_jit.py
+++ b/src/tests/test_jit.py
@@ -1,5 +1,3 @@
-import configparser
-import os
 import pytest
 from duplocloud.client import DuploClient
 from duplocloud.errors import DuploError
@@ -49,95 +47,6 @@ class TestJIT:
       assert o.get("Token", None) is not None
     except DuploError as e:
       pytest.fail(f"Failed to get admin k8s credentials: {e}")
+  
+  
 
-  @pytest.mark.integration
-  @pytest.mark.order(10)
-  def test_update_aws_config_nonexistent_dir(self, duplo: DuploClient, tmp_path):
-    config_dir = tmp_path / "nonexistent" / "nested"
-    config_file = config_dir / "config"
-    os.environ["AWS_CONFIG_FILE"] = str(config_file)
-    r = duplo.load("jit")
-    profile_name = "test_profile"
-    assert not config_dir.exists()
-    result = r.update_aws_config(profile_name)
-    assert "added" in result["message"].lower()
-    assert config_dir.exists()
-    assert config_file.exists()
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    profile_section = f"profile {profile_name}"
-    assert config.has_section(profile_section)
-    os.environ.pop("AWS_CONFIG_FILE", None)
-
-  @pytest.mark.integration
-  @pytest.mark.order(10)
-  def test_update_kubeconfig(self, duplo: DuploClient, tmp_path):
-    kubeconfig_file = tmp_path / "config"
-    os.environ["KUBECONFIG"] = str(kubeconfig_file)
-    r = duplo.load("jit")
-    def mock_k8s_context(planId=None):
-      return {
-        "Name": "test-cluster",
-        "ApiServer": "https://test-cluster:6443",
-        "Token": "test-token",
-        "DefaultNamespace": "default"
-      }
-    r.k8s_context = mock_k8s_context
-    result = r.update_kubeconfig(planId="test-plan")
-    assert "successfully" in result["message"].lower()
-    assert kubeconfig_file.exists()
-    import yaml
-    with open(kubeconfig_file) as f:
-      config = yaml.safe_load(f)
-    assert "clusters" in config
-    assert "users" in config
-    assert "contexts" in config
-    assert config["current-context"] == "test-plan"
-    os.environ.pop("KUBECONFIG", None)
-
-  @pytest.mark.integration
-  @pytest.mark.order(10)
-  def test_update_kubeconfig_nonexistent_dir(self, duplo: DuploClient, tmp_path):
-    kube_dir = tmp_path / "nonexistent" / "nested" / ".kube"
-    kubeconfig_file = kube_dir / "config"
-    os.environ["KUBECONFIG"] = str(kubeconfig_file)
-    r = duplo.load("jit")
-    def mock_k8s_context(planId=None):
-      return {
-        "Name": "test-cluster",
-        "ApiServer": "https://test-cluster:6443",
-        "Token": "test-token",
-        "DefaultNamespace": "default"
-      }
-    r.k8s_context = mock_k8s_context
-    assert not kube_dir.exists()
-    result = r.update_kubeconfig(planId="test-plan")
-    assert "successfully" in result["message"].lower()
-    assert kube_dir.exists()
-    assert kubeconfig_file.exists()
-    import yaml
-    with open(kubeconfig_file) as f:
-      config = yaml.safe_load(f)
-    assert "clusters" in config
-    assert "users" in config
-    assert "contexts" in config
-    os.environ.pop("KUBECONFIG", None)
-
-  @pytest.mark.integration
-  @pytest.mark.order(10)
-  def test_update_aws_config(self, duplo: DuploClient, tmp_path):
-    config_file = tmp_path / "config"
-    os.environ["AWS_CONFIG_FILE"] = str(config_file)
-    r = duplo.load("jit")
-    profile_name = "test_profile"
-    result = r.update_aws_config(profile_name)
-    assert "added" in result["message"].lower()
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    profile_section = f"profile {profile_name}"
-    assert config.has_section(profile_section)
-    assert config.get(profile_section, "region") == os.getenv("AWS_DEFAULT_REGION", "us-west-2")
-    assert "duploctl jit aws" in config.get(profile_section, "credential_process")
-    result = r.update_aws_config(profile_name)
-    assert "updated" in result["message"].lower()
-    os.environ.pop("AWS_CONFIG_FILE", None)


### PR DESCRIPTION
### **User description**
This reverts commit ecb0cf3f688b7f4b49c6debd94eb03a2f9aa932e.

## Describe Changes

## Link to Issues  

## PR Review Checklist  

- [ ] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [ ] Make sure to note changes in Changelog


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted AWS config update logic to prevent profile overwriting

- Removed comprehensive test coverage for config file operations

- Simplified profile existence checking mechanism

- Eliminated directory creation functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original AWS Config Logic"] --> B["Reverted Implementation"]
  C["Comprehensive Tests"] --> D["Basic Tests Only"]
  B --> E["Profile Overwrite Prevention"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jit.py</strong><dd><code>Revert AWS config profile update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/jit.py

<ul><li>Reverted AWS config profile update logic to original implementation<br> <li> Changed from <code>has_section()</code> to try/except KeyError approach<br> <li> Removed profile update functionality, only allows adding new profiles<br> <li> Eliminated automatic directory creation with <code>os.makedirs()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/169/files#diff-7e55cc23580ca0ed29a44b891d834a6cf3251a2a5a785f6291a4efe95b54cdf6">+13/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jit.py</strong><dd><code>Remove comprehensive config file tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_jit.py

<ul><li>Removed all comprehensive test methods for AWS config and kubeconfig<br> <li> Deleted imports for <code>configparser</code> and <code>os</code> modules<br> <li> Eliminated tests for directory creation and profile update scenarios<br> <li> Kept only basic JIT functionality tests</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/169/files#diff-147482cb3678a8293a65528253909fb168a7b7b21108bd1312cbd59220f23c88">+2/-93</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

