### PR TITLE
DUPLO-35823 feat(ecs): update find def to use service family name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update ECS find_def to use the TaskDefFamily from the service endpoint, fixing update_image when the service name and task definition family are different.
+
 ## [0.3.6] - 2025-08-19
 
-### Fixed 
+### Fixed
 
 - Create ticket command supports message processing as optional.
 - redirect based interactive login flow. Now safari and other browsers are supported with interactive login because the UI can give the token to the callback with a get request.

--- a/src/duplo_resource/ecs_service.py
+++ b/src/duplo_resource/ecs_service.py
@@ -83,7 +83,9 @@ class DuploEcsService(DuploTenantResourceV2):
       DuploError: If the ECS task definition could not be found.
     """
     name = self.prefixed_name(name)
-    tdf = self.find_task_def_family(name)
+    svcFam = self.find_service_family(name)
+    family = svcFam["TaskDefFamily"]
+    tdf = self.find_task_def_family(family)
     arn = tdf["VersionArns"][-1]
     return self.find_def_by_arn(arn)
 


### PR DESCRIPTION
### **User description**
## Describe Changes

- updates find_def to first look up input service name's family name, then uses it to look up task def

## Link to Issues  

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog

## Copilot Summary

This pull request fixes an issue with how ECS task definitions are looked up when updating service images, ensuring the correct task definition family is used even when the service name and task definition family differ. It also adds a unit test to verify this behavior.

Bug fix for ECS service image updates:

* Updated `find_def` in `src/duplo_resource/ecs_service.py` to use the `TaskDefFamily` from the service endpoint, ensuring the correct task definition is found when the service name and task definition family are different.

Testing improvements:

* Added a new unit test `test_find_def_uses_taskdef_family_from_service` in `src/tests/test_ecs_service.py` to verify that `find_def` uses the task definition family from the service endpoint.

Documentation:

* Updated the `CHANGELOG.md` to document the bug fix for ECS service image updates.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix ECS task definition lookup using service family name

- Add unit test for task definition family resolution

- Update changelog with bug fix documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Name"] --> B["find_service_family()"]
  B --> C["TaskDefFamily"]
  C --> D["find_task_def_family()"]
  D --> E["Task Definition"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ecs_service.py</strong><dd><code>Update find_def to use service family name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/ecs_service.py

<ul><li>Modified <code>find_def</code> method to use service family lookup<br> <li> Added intermediate step to get <code>TaskDefFamily</code> from service endpoint<br> <li> Changed task definition family resolution logic</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/177/files#diff-00061cbcd7c679c36b38e0b31a9dbe5c3d1f9be94c11602332a5330f96126458">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ecs_service.py</strong><dd><code>Add unit test for service family lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_ecs_service.py

<ul><li>Added new unit test <code>test_find_def_uses_taskdef_family_from_service</code><br> <li> Tests that <code>find_def</code> uses task definition family from service endpoint<br> <li> Verifies correct method calls and return values</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/177/files#diff-a4cbb173d0196c88567a454c0cb9f6641ebe4d4cd2ffdaedf92d80e0081dbccf">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document ECS find_def bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added Fixed section for version [Unreleased]<br> <li> Documented ECS find_def bug fix<br> <li> Minor formatting fix (trailing space removal)</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/177/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

