### PR TITLE
DUPLO-36861: Spelling errors in error messages and doc strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed agentHostTenantId from ticket creation payload.
 - Update ECS find_def to use the TaskDefFamily from the service endpoint, fixing update_image when the service name and task definition family are different.
+- Updated some spelling errors in error messages and doc strings
 
 ## [0.3.6] - 2025-08-19
 

--- a/src/duplo_resource/aws_secret.py
+++ b/src/duplo_resource/aws_secret.py
@@ -31,7 +31,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
   def find(self, 
            name: args.NAME,
            show_sensitive: args.SHOW_SENSITIVE=False) -> dict:
-    """Find as AWS Secretmanager secret by name and return its content
+    """Find an AWS Secrets Manager secret by name and return its content
 
     Usage: cli usage
       ```sh
@@ -74,7 +74,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
              data: args.DATAMAP=None,
              value: args.CONTENT=None,
              dryrun: args.DRYRUN=False) -> dict:
-    """Create an AWS Secretmanager Secret
+    """Create an AWS Secrets Manager Secret
 
     Using DuploCloud's native support for AWS Secrets Manager, you can create a new secret. This method acts and feels like how the Kubernetes secrets work within this cli. Supports the secrets value as a string or a key/value JSON object where each value is a string. If you give a JSON object with any key that is not a string, the entire value will be simply a string with a JSON value. The examples below mostly include the `--dry-run` so you can see the output. Simply remove that to actually create the secret.
 
@@ -110,12 +110,12 @@ class DuploAwsSecret(DuploTenantResourceV3):
     Args:
       name: The name of the AWS Secret to create.
       body: The full body of an AWS Secrets Manager secret for DuploCloud.
-      data: A map of key-value pairs to be merged into the SecretString field of the AWS Secretmanager secret. Can't be used with the value argument. A datamap is a combination of all of the `--from-literal` and `--from-file` flags.
-      value: The value of the AWS Secretmanager secret. This overwrites the existing value! Can't be used with the data argument.
+      data: A map of key-value pairs to be merged into the SecretString field of the AWS Secrets Manager secret. Can't be used with the value argument. A datamap is a combination of all of the `--from-literal` and `--from-file` flags.
+      value: The value of the AWS Secrets Manager secret. This overwrites the existing value! Can't be used with the data argument.
       dryrun: If true, returns the body that would be sent to the API without actually creating the resource.
 
     Returns: 
-      message: Either a succes message is returned or if --dry-run is passed then the body is what is returned. 
+      message: Either a success message is returned or if --dry-run is passed then the body is what is returned. 
       
     Raises:
       DuploError: If the AWS secret already exists.
@@ -148,7 +148,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
              data: args.DATAMAP=None,
              value: args.CONTENT=None,
              dryrun: args.DRYRUN=False) -> dict:
-    """Update an AWS Secretmanager secret.
+    """Update an AWS Secrets Manager secret.
 
     Follows all the same arguments and style of the create method. This requires the secret to already exist. 
 
@@ -165,7 +165,7 @@ class DuploAwsSecret(DuploTenantResourceV3):
       dryrun: If true, returns the body that would be sent to the API without actually creating the resource.
 
     Returns: 
-      message: Either a succes message is returned or if --dry-run is passed then the body is what is returned. 
+      message: Either a success message is returned or if --dry-run is passed then the body is what is returned. 
       
     Raises:
       DuploError: If the AWS secret could not be found or doesn't exist.
@@ -200,9 +200,9 @@ class DuploAwsSecret(DuploTenantResourceV3):
   @Command()
   def delete(self,
              name: args.NAME) -> dict:
-    """Delete an AWS Secretmanager secret.
+    """Delete an AWS Secrets Manager secret.
 
-    Deletes an AWS Secretmanager secret by name.
+    Deletes an AWS Secrets Manager secret by name.
 
     Usage: cli
       ```sh
@@ -210,8 +210,8 @@ class DuploAwsSecret(DuploTenantResourceV3):
       ```
 
     Args:
-      name: The name of an AWS Secretmanager secret to delete. This can either be the short name or the full name including the tenant prefix.
-      wait: Wait for an AWS Secretmanager secret to be deleted.
+      name: The name of an AWS Secrets Manager secret to delete. This can either be the short name or the full name including the tenant prefix.
+      wait: Wait for an AWS Secrets Manager secret to be deleted.
 
     Returns:
       message: A success message.

--- a/src/duplocloud/args.py
+++ b/src/duplocloud/args.py
@@ -37,11 +37,11 @@ CONTEXT = Arg("context", "--ctx",
               env='DUPLO_CONTEXT')
 
 HOST = Arg('host', '-H', 
-            help='The url to specified duplo portal.',
+            help='The URL to specified Duplo portal.',
             env='DUPLO_HOST')
 
 TOKEN = Arg('token', '-t', 
-            help='The token to authenticate with duplocloud portal api.',
+            help='The token to authenticate with DuploCloud Portal API.',
             env='DUPLO_TOKEN')
 
 TENANT = Arg("tenant", "-T",
@@ -65,7 +65,7 @@ PLAN = Arg("plan", "-P",
             env='DUPLO_PLAN')
 """Plan Name
 
-This is another high level placement style argument. This is used to scope the command to a specific plan aka infrastructure. 
+Scopes the command to a specific infrastructure plan.
 """
 
 BODY = Arg("file", "-f", "--cli-input",
@@ -74,7 +74,7 @@ BODY = Arg("file", "-f", "--cli-input",
             action=YamlAction)
 """File Body  
 
-This is the file path to a file with the specified resources body within. Each Resource will have it's own schema for the body. This is a yaml/json file that will be parsed and used as the body of the request. View the docs for each individual resource to see the schema for the body.
+This is the file path to a file with the specified resource's body within. Each Resource will have its own schema for the body. This is a YAML/JSON file that will be parsed and used as the body of the request. View the docs for each individual resource to see the schema for the body.
 """
 
 DATAMAP = Arg("fromfile","--from-file", "--from-literal",

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -61,7 +61,7 @@ class DuploClient():
                wait: args.WAIT=False):
     """DuploClient Constructor
     
-    Creates an instance of a duplocloud client configured for a certain portal. All of the arguments are optional and can be set in the environment or in the config file. The types of each ofthe arguments are annotated types that are used by argparse to create the command line arguments.
+    Creates an instance of a duplocloud client configured for a certain portal. All of the arguments are optional and can be set in the environment or in the config file. The types of each of the arguments are annotated types that are used by argparse to create the command line arguments.
 
     Args:
       host: The host of the Duplo instance.
@@ -360,11 +360,12 @@ Available Resources:
         timeout = self.timeout
       )
     except requests.exceptions.Timeout as e:
-      raise DuploError("Timeout connecting to Duplo", 500) from e
+      raise DuploError("Request timed out while connecting to Duplo", 500) from e
     except requests.exceptions.ConnectionError as e:
-      raise DuploError("A conntection error occured with Duplo", 500) from e
+      print(e)
+      raise DuploError("Failed to establish connection with Duplo", 500) from e
     except requests.exceptions.RequestException as e:
-      raise DuploError("Error connecting to Duplo with a request exception", 500) from e
+      raise DuploError("Failed to send request to Duplo", 500) from e
     return self.__validate_response(response)
   
   def post(self, path: str, data: dict={}):
@@ -449,9 +450,9 @@ Available Resources:
     try:
       return jmespath.search(self.query, data)
     except jmespath.exceptions.ParseError as e:
-      raise DuploError("Invalid jmespath query", 500) from e
+      raise DuploError("Invalid JMESPath query - parsing failed", 500) from e
     except jmespath.exceptions.JMESPathTypeError as e:
-      raise DuploError("Invalid jmespath query", 500) from e
+      raise DuploError("Invalid JMESPath query - data type mismatch", 500) from e
     
   def load(self, kind: str) -> T:
     """Load Resource

--- a/src/duplocloud/commander.py
+++ b/src/duplocloud/commander.py
@@ -77,7 +77,7 @@ def extract_args(function: Callable) -> List[Arg]:
 def aliased_method(cls: Type, command: str) -> str:
   """Aliased Method
   
-  Given a name of a command, check the schema and find the real method name because the command might be aliased.
+  Given the name of a command, check the schema and find the real method name because the command might be aliased.
   The given class will be used to discover any ancestors because the command may actually come from a parent class.
 
   Args:

--- a/src/duplocloud/formats.py
+++ b/src/duplocloud/formats.py
@@ -2,7 +2,7 @@
 def tostring(obj):
   """Converts a python object to a string.
 
-  The default formatter with no fancy pants tranforming.
+  The default formatter that performs basic string conversion.
 
   Args:
     obj: The python object to convert.


### PR DESCRIPTION
### **User description**
## Describe Changes

- Updated some spelling errors in error messages and doc strings

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-36861

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Documentation


___

### **Description**
- Fixed spelling errors in AWS Secrets Manager docstrings

- Corrected error messages for better clarity

- Updated argument descriptions for consistency

- Added changelog entry for documentation improvements


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_secret.py</strong><dd><code>AWS Secrets Manager spelling corrections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/aws_secret.py

<ul><li>Fixed "Secretmanager" to "Secrets Manager" in docstrings<br> <li> Corrected "succes" to "success" in return descriptions<br> <li> Updated "as" to "an" in find method docstring</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-34abfd7c842718be581a6b194282f9a51a493d1c984ce3310b77316480f500fe">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>args.py</strong><dd><code>Argument help text spelling fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplocloud/args.py

<ul><li>Fixed "url" to "URL" in HOST argument help<br> <li> Corrected "duplocloud portal api" to "DuploCloud Portal API"<br> <li> Updated plan description for better clarity<br> <li> Fixed "it's" to "its" in BODY argument description</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-10408bee68a44ad34e4226ec91f20e3277d2d637fd8e17d3482fea817838ec96">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Client error messages and docstring fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplocloud/client.py

<ul><li>Fixed "ofthe" to "of the" in constructor docstring<br> <li> Improved error messages for connection timeouts and failures<br> <li> Updated JMESPath error messages for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-ed921a2441e8df6f226f7024b875dea79afcd0d87e1326c37b19d232dba3f740">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commander.py</strong><dd><code>Minor docstring grammar fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplocloud/commander.py

- Updated docstring from "Given a name" to "Given the name"


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-76bc85ae5e9281fbbae1c51d5775fc1663f2b323368722e8bf16a21578a9b9f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>formats.py</strong><dd><code>Function docstring improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplocloud/formats.py

- Improved docstring description for tostring function


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-087be31cbe3f6a58ce240dc06abf7afcc7d6182a60d1c10835d22aab8c1984ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for spelling fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Added entry documenting spelling error fixes


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/180/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

