### PR TITLE
DUPLO-37215 Allow min or max setting on ASG to be zero (0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ASG scale command to properly handle zero values for min and max parameters. Previously, setting min=0 or max=0 would incorrectly raise a "Must provide either min or max" error.
 - Removed agentHostTenantId from ticket creation payload.
 - Update ECS find_def to use the TaskDefFamily from the service endpoint, fixing update_image when the service name and task definition family are different.
 - Added debug logging to wait functions

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -198,7 +198,7 @@ class DuploAsg(DuploTenantResourceV2):
     Raises:
       DuploError: If neither min nor max is provided, or if the scaling operation fails.
     """
-    if not min and not max:
+    if min is None and max is None:
       raise DuploError("Must provide either min or max")
     asg = self.find(name)
     data = {
@@ -207,9 +207,9 @@ class DuploAsg(DuploTenantResourceV2):
       "MinSize": asg.get("MinSize", None),# this really is a string unlike the other two? 
       "MaxSize": asg.get("MaxSize", None),
     }
-    if min:
+    if min is not None:
       data["MinSize"] = str(min)
-    if max:
+    if max is not None:
       data["MaxSize"] = max
     return self.update(data)
   

--- a/src/tests/test_asg.py
+++ b/src/tests/test_asg.py
@@ -66,6 +66,42 @@ class TestAsg:
 
     @pytest.mark.integration
     @pytest.mark.dependency(depends=["create_asg"], scope="session")
+    @pytest.mark.order(5)
+    def test_scale_asg_min_zero(self, asg_resource):
+        """Test scaling ASG with minimum size of 0."""
+        r, asg_name = asg_resource
+        response = execute_test(r.scale, asg_name, min=0)
+        assert "Successfully updated asg" in response["message"]
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_asg"], scope="session")
+    @pytest.mark.order(5)
+    def test_scale_asg_max_zero(self, asg_resource):
+        """Test scaling ASG with maximum size of 0."""
+        r, asg_name = asg_resource
+        response = execute_test(r.scale, asg_name, max=0)
+        assert "Successfully updated asg" in response["message"]
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_asg"], scope="session")
+    @pytest.mark.order(5)
+    def test_scale_asg_both_zero(self, asg_resource):
+        """Test scaling ASG with both min and max size of 0."""
+        r, asg_name = asg_resource
+        response = execute_test(r.scale, asg_name, min=0, max=0)
+        assert "Successfully updated asg" in response["message"]
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_asg"], scope="session")
+    @pytest.mark.order(5)
+    def test_scale_asg_no_params_error(self, asg_resource):
+        """Test that scaling ASG with no parameters raises an error."""
+        r, asg_name = asg_resource
+        with pytest.raises(DuploError, match="Must provide either min or max"):
+            r.scale(asg_name)
+
+    @pytest.mark.integration
+    @pytest.mark.dependency(depends=["create_asg"], scope="session")
     @pytest.mark.order(6)
     def test_delete_asg(self, asg_resource):
         r, _ = asg_resource


### PR DESCRIPTION
### **User description**
## Describe Changes

DUPLO-37215 Allow min or max setting on ASG to be zero (0) by checking for None instead of falsey values which treats zero (0) as false.

## Link to Issues 

https://app.clickup.com/t/8655600/DUPLO-37215

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed ASG scale command to accept zero values

- Changed falsey value checks to explicit None checks

- Added comprehensive tests for zero value scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ASG scale method"] --> B["Check parameters"]
  B --> C["Previous: falsey check"]
  B --> D["Fixed: None check"]
  C --> E["Zero treated as false"]
  D --> F["Zero allowed as valid"]
  F --> G["Update ASG configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asg.py</strong><dd><code>Fix zero value handling in ASG scale method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/duplo_resource/asg.py

<ul><li>Changed parameter validation from falsey to None checks<br> <li> Fixed min and max parameter handling to allow zero values<br> <li> Updated conditional logic for setting MinSize and MaxSize</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/181/files#diff-60df692f7342064f0679cc87ffcd78c83f6107e5750ae162e9e446e3e27b7ad8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_asg.py</strong><dd><code>Add comprehensive tests for zero value scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/test_asg.py

<ul><li>Added test for scaling ASG with min=0<br> <li> Added test for scaling ASG with max=0<br> <li> Added test for scaling ASG with both min=0 and max=0<br> <li> Added test to verify error when no parameters provided</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/181/files#diff-a8011d44133b22fa8b9ed402ff058dc4469923ba774e2939b019502d43ae4a69">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document ASG scale zero value fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the ASG scale command fix<br> <li> Explained the previous incorrect behavior with zero values</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/duploctl/pull/181/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

