### PR TITLE
Fix batch job links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated broken links in batch documentation
 - `brew install duploctl --with-pip` fails due to `pydantic_core` sdist requiring Rust toolchain in Homebrew sandbox; made `duplocloud-sdk` an optional dependency
 - `brew install duploctl` binary crashes with `No module named 'duplocloud.client'`; added missing hidden imports and package metadata to PyInstaller spec
 - Fixed `storageclass` commands (`find`, `update`, `create --wait`, `apply`) failing because names were not tenant-prefixed. Enabled `prefixed=True` on the resource.

--- a/src/duplo_resource/batch_compute.py
+++ b/src/duplo_resource/batch_compute.py
@@ -11,7 +11,7 @@ class DuploBatchCompute(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_definition.py
+++ b/src/duplo_resource/batch_definition.py
@@ -11,7 +11,7 @@ class DuploBatchDefinition(DuploResourceV3):
   Manage batch Job Definitions as a resource in Duplo.
 
   Read more docs here:
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_job.py
+++ b/src/duplo_resource/batch_job.py
@@ -11,7 +11,7 @@ class DuploBatchJob(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_queue.py
+++ b/src/duplo_resource/batch_queue.py
@@ -11,7 +11,7 @@ class DuploBatchQueue(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_scheduling_policy.py
+++ b/src/duplo_resource/batch_scheduling_policy.py
@@ -9,7 +9,7 @@ class DuploBatchSchedulingPolicy(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):


### PR DESCRIPTION
## Fixed broken links in Batch docs (BatchCompute, BatchDefinition, BatchJob, BatchQueue, BatchSchedulingPolicy)

## [Link to Issues  ](https://cli.duplocloud.com/BatchCompute/)

