### PR TITLE
fix: use V3 containerimage endpoint for service update_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `service update_image` now uses the V3 containerimage endpoint and supports updating main, sidecar, and init container images in a single call
+
 ## [0.4.3] - 2026-03-18
 
 ### Added

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -343,63 +343,25 @@ class DuploService(DuploResourceV2):
     Returns:
       message: Success message
     """
-    if [image, container_image, init_container_image].count(None) != 2:
+    if not any([image, container_image, init_container_image]):
       raise DuploError("Provide a service image, container images, or init container images.")
     self.duplo.logger.debug("UPDATE IMAGE")
-    service = self.find(name)
-    data = {}
-    updated_containers = []
-    not_found_containers = []
-
-    if not image:
-      other_docker_config = loads(service["Template"].get("OtherDockerConfig", "{}"))
-      if container_image:
-        images = container_image
-        containers = other_docker_config.get("additionalContainers", [])
-      elif init_container_image:
-        images = init_container_image
-        containers = other_docker_config.get("initContainers", [])
-
-      for key, value in images:
-        container_found = False
-        for c in containers:
-          if c["name"] == key:
-            c["image"] = value
-            updated_containers.append(key)
-            container_found = True
-            break
-        if not container_found:
-          not_found_containers.append(key)
-
-      if not updated_containers:
-        raise DuploError(f"No matching containers found in service '{name}'")
-
-      data = {
-        "Name": name,
-        "OtherDockerConfig": dumps(other_docker_config),
-        "AllocationTags": service["Template"].get("AllocationTags", "")
-      }
-
-    else:
-      data = {
-        "Name": name,
-        "Image": image,
-        "AllocationTags": service["Template"].get("AllocationTags", "")
-      }
-
-    self.client.post(self.endpoint("ReplicationControllerChange"), data)
-
+    payload = []
+    if image:
+      payload.append({"ContainerName": "duplo-main-container", "ImageName": image})
+    for cname, cimage in (container_image or []):
+      payload.append({"ContainerName": cname, "ImageName": cimage})
+    for cname, cimage in (init_container_image or []):
+      payload.append({"ContainerName": cname, "ImageName": cimage})
+    endpoint = f"v3/subscriptions/{self.tenant_id}/containers/replicationController/{name}/containerimage"
+    old = None
+    if self.duplo.wait:
+      old = self.find(name)
+    self.client.put(endpoint, payload)
     if self.duplo.wait:
       self.duplo.logger.debug("Wait enabled, beginning wait process")
-      self._wait(service, data)
-
-    response_message = "Successfully updated image for service."
-    if updated_containers:
-      response_message += f" Updated containers: {', '.join(updated_containers)}."
-    if not_found_containers:
-      response_message += f" Could not find containers: {', '.join(not_found_containers)}."
-
-    return {"message": response_message}
+      self._wait(old, {"Name": name, "Image": image or ""})
+    return {"message": f"Successfully updated image for service '{name}'."}
 
   @Command()
   def update_env(self,

--- a/src/tests/test_service_update_image.py
+++ b/src/tests/test_service_update_image.py
@@ -1,6 +1,3 @@
-import json
-from unittest.mock import ANY
-
 import pytest
 
 from duplo_resource.service import DuploService
@@ -13,19 +10,10 @@ invalid_kwargs = [
   },
   {
     'name': 'widget',
-    'image': 'nginx:latest',
-    'container_image': [('widget-sidecar', 'widget:v2')]
+    'image': None,
+    'container_image': None,
+    'init_container_image': None,
   },
-  {
-    'name': 'widget',
-    'image': 'nginx:latest',
-    'init_container_image': [('widget-init', 'widget:v2')],
-  },
-  {
-    'name': 'widget',
-    'container_image': [('widget-init', 'widget:v2')],
-    'init_container_image': [('widget-init', 'widget:v2')],
-  }
 ]
 
 
@@ -35,399 +23,133 @@ def test_invalid_args_raise_errors(invalid_kwargs, mocker):
   mock_client = mocker.MagicMock()
   mock_client.load_client.return_value = mock_client
 
-  # DuploError is generic. It doesn't specifically identify bad input. We have to match the error message or we
-  # can get false positives if the method raises a DuploError later about something else.
   with pytest.raises(DuploError, match='Provide a service image, container images, or init container images.'):
     DuploService(mock_client).update_image(**invalid_kwargs)
 
 
-no_matching_container_tests = [
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'container_image': [('not-widget-sidecar', 'widget:v2')]
-    }
-  ),
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'init_container_image': [('not-widget-init', 'widget:v2')]
-    }
-  )
-]
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize('service_definition,kwargs', no_matching_container_tests)
-def test_no_matching_container_raises_error(service_definition, kwargs, mocker):
-  mocker.patch(
-    'duplo_resource.service.DuploService.find',
-    mocker.MagicMock(return_value=service_definition)
-  )
-  mock_client = mocker.MagicMock()
-  mock_client.load_client.return_value = mock_client
-
-  # DuploError is generic. It doesn't specifically identify bad input. We have to match the error message or we
-  # can get false positives if the method raises a DuploError later about something else.
-  with pytest.raises(DuploError, match=r'No matching containers found in service .*'):
-    DuploService(mock_client).update_image(**kwargs)
-
-
-
 post_data_tests = [
-  # Update one service.
+  # Update main image only.
   (
-    {'Template': {}},
     {
       'name': 'widget',
       'image': 'widget:v1'
     },
-    {
-      'Name': 'widget',
-      'Image': 'widget:v1',
-      'AllocationTags': '',
-    },
+    [
+      {'ContainerName': 'duplo-main-container', 'ImageName': 'widget:v1'},
+    ],
   ),
 
   # Update one additional container.
   (
     {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
       'name': 'widget',
       'container_image': [('widget-sidecar', 'widget:v2')]
     },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'additionalContainers': [{
-        'name': 'widget-sidecar',
-        'image': 'widget:v2',
-      }]}),
-      'AllocationTags': '',
-    },
+    [
+      {'ContainerName': 'widget-sidecar', 'ImageName': 'widget:v2'},
+    ],
   ),
 
-  # Update first of two additional containers.
+  # Update two additional containers.
   (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'container_image': [('widget-sidecar1', 'widget:v2')]
-    },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v2',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v1',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  ),
-
-  # Update second of two additional containers.
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'container_image': [('widget-sidecar2', 'widget:v2')]
-    },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  ),
-
-  # Update two of two additional containers.
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
     {
       'name': 'widget',
       'container_image': [('widget-sidecar1', 'widget:v2'), ('widget-sidecar2', 'widget:v2')]
     },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar1',
-          'image': 'widget:v2',
-        },
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  ),
-
-  # Update two of one additional containers.
-  # Arguably, trying to update images for two additional containers in a service that only has one additional container
-  # should raise an error. This test was written to assert existing behavior to preserve backwards compatibility.
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'container_image': [('widget-sidecar1', 'widget:v2'), ('widget-sidecar2', 'widget:v2')]
-    },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'additionalContainers': [
-        {
-          'name': 'widget-sidecar2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
+    [
+      {'ContainerName': 'widget-sidecar1', 'ImageName': 'widget:v2'},
+      {'ContainerName': 'widget-sidecar2', 'ImageName': 'widget:v2'},
+    ],
   ),
 
   # Update one init container.
   (
     {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
       'name': 'widget',
       'init_container_image': [('widget-init', 'widget:v2')]
     },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'initContainers': [{
-        'name': 'widget-init',
-        'image': 'widget:v2',
-      }]}),
-      'AllocationTags': '',
-    },
+    [
+      {'ContainerName': 'widget-init', 'ImageName': 'widget:v2'},
+    ],
   ),
 
-  # Update first of two init containers.
+  # Update two init containers.
   (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'init_container_image': [('widget-init1', 'widget:v2')]
-    },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v2',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v1',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  ),
-
-  # Update second of two init containers.
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
-    {
-      'name': 'widget',
-      'init_container_image': [('widget-init2', 'widget:v2')]
-    },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  ),
-
-  # Update two of two init containers.
-  (
-    {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v1',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v1',
-        }
-      ]})}
-    },
     {
       'name': 'widget',
       'init_container_image': [('widget-init1', 'widget:v2'), ('widget-init2', 'widget:v2')]
     },
-    {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init1',
-          'image': 'widget:v2',
-        },
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
+    [
+      {'ContainerName': 'widget-init1', 'ImageName': 'widget:v2'},
+      {'ContainerName': 'widget-init2', 'ImageName': 'widget:v2'},
+    ],
   ),
 
-  # Update two of one init containers.
-  # Arguably, trying to update images for two init containers in a service that only has one init container should
-  # raise an error. When init containers were added, support for additional containers already existed and it allowed
-  # this case. Because images for additional containers and init containers work the same, support for init containers
-  # followed the pattern set for additional containers.
+  # Mixed: main image + additional container.
   (
     {
-      'Template': {'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v1',
-        }
-      ]})}
+      'name': 'widget',
+      'image': 'nginx:latest',
+      'container_image': [('widget-sidecar', 'widget:v2')]
     },
+    [
+      {'ContainerName': 'duplo-main-container', 'ImageName': 'nginx:latest'},
+      {'ContainerName': 'widget-sidecar', 'ImageName': 'widget:v2'},
+    ],
+  ),
+
+  # Mixed: main image + init container.
+  (
     {
       'name': 'widget',
-      'init_container_image': [('widget-init1', 'widget:v2'), ('widget-init2', 'widget:v2')]
+      'image': 'nginx:latest',
+      'init_container_image': [('widget-init', 'widget:v2')]
     },
+    [
+      {'ContainerName': 'duplo-main-container', 'ImageName': 'nginx:latest'},
+      {'ContainerName': 'widget-init', 'ImageName': 'widget:v2'},
+    ],
+  ),
+
+  # Mixed: additional container + init container.
+  (
     {
-      'Name': 'widget',
-      'OtherDockerConfig': json.dumps({'initContainers': [
-        {
-          'name': 'widget-init2',
-          'image': 'widget:v2',
-        }
-      ]}),
-      'AllocationTags': '',
-    }
-  )
+      'name': 'widget',
+      'container_image': [('widget-sidecar', 'widget:v2')],
+      'init_container_image': [('widget-init', 'widget:v2')]
+    },
+    [
+      {'ContainerName': 'widget-sidecar', 'ImageName': 'widget:v2'},
+      {'ContainerName': 'widget-init', 'ImageName': 'widget:v2'},
+    ],
+  ),
+
+  # Mixed: all three types.
+  (
+    {
+      'name': 'widget',
+      'image': 'nginx:latest',
+      'container_image': [('widget-sidecar', 'envoy:v1')],
+      'init_container_image': [('widget-init', 'busybox:1.36')]
+    },
+    [
+      {'ContainerName': 'duplo-main-container', 'ImageName': 'nginx:latest'},
+      {'ContainerName': 'widget-sidecar', 'ImageName': 'envoy:v1'},
+      {'ContainerName': 'widget-init', 'ImageName': 'busybox:1.36'},
+    ],
+  ),
 ]
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize('service_definition,kwargs,post_data', post_data_tests)
-def test_post_data(service_definition, kwargs, post_data, mocker):
-  service = service_definition
-  mocker.patch(
-    'duplo_resource.service.DuploService.find',
-    mocker.MagicMock(return_value=service)
-  )
-  post_data = post_data
+@pytest.mark.parametrize('kwargs,expected_payload', post_data_tests)
+def test_post_data(kwargs, expected_payload, mocker):
   mock_client = mocker.MagicMock()
   mock_client.load_client.return_value = mock_client
   mock_client.wait = False
-  DuploService(mock_client).update_image(**kwargs)
-  mock_client.post.assert_called_once_with(ANY, post_data)
+  svc = DuploService(mock_client)
+  svc._tenant_id = 'test-tenant-id'
+  svc.update_image(**kwargs)
+  name = kwargs['name']
+  expected_endpoint = f"v3/subscriptions/test-tenant-id/containers/replicationController/{name}/containerimage"
+  mock_client.put.assert_called_once_with(expected_endpoint, expected_payload)


### PR DESCRIPTION
## Describe Changes

Switches `service update_image` from the V2 `ReplicationControllerChange` endpoint to the V3 `containerimage` endpoint.

The V2 endpoint resets boolean service properties (e.g. `IsReplicaCollocationAllowed`) as a side effect of image updates, causing allocation failures for customers who have enabled replica collocation. The V3 endpoint updates only container images without touching other service properties.

Changes:
- Main container image uses the reserved name `duplo-main-container` per the V3 endpoint contract
- Sidecar and init container images are passed by their actual container names
- All three image types can now be updated in a single CLI call (previously mutually exclusive)
- Removes ~50 lines of client-side `OtherDockerConfig` JSON parsing/serialization that the server now handles

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-42207

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog