### PR TITLE
fix: promote HTTP 400 "not found" to DuploNotFound for RDS apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+
 ## [0.4.3] - 2026-03-18
 
 ### Added

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -159,6 +159,8 @@ class DuploAPI():
       raise DuploError(f"Unauthorized: {response.text}", response.status_code)
 
     if response.status_code == 400:
+      if "not found" in response.text.lower():
+        raise DuploNotFound(response.text)
       raise DuploError(response.text, response.status_code)
 
     raise DuploError(f"Duplo responded with ({response.status_code}): {response.text}", response.status_code)


### PR DESCRIPTION
## Describe Changes

Some DuploCloud APIs (e.g. RDS) return HTTP 400 instead of 404 when a resource does not exist. Since v0.4.3 narrowed `apply()` to catch only `DuploNotFound`, these 400 responses escaped uncaught, breaking `duploctl rds apply --wait` for new instances (exit code 144 = 400 % 256).

This adds a check in `_validate_response`: when the API returns HTTP 400 with "not found" in the body, it raises `DuploNotFound` instead of `DuploError`, so `apply()` correctly falls through to `create()`.

## Link to Issues

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog