### PR TITLE
fix: show only DB name in rds delete output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 
 ## [0.4.3] - 2026-03-18

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -52,6 +52,30 @@ class DuploRDS(DuploResourceV3):
     return response.json()
   
   @Command()
+  def delete(self,
+             name: args.NAME) -> dict:
+    """Delete a DB instance by name.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl rds delete <name>
+      ```
+
+    Args:
+      name: The name of the DB instance to delete.
+
+    Returns:
+      message: A success message.
+
+    Raises:
+      DuploError: If the DB instance could not be found or deleted.
+    """
+    self.client.delete(self.endpoint(name))
+    return {
+      "message": f"{name} deleted"
+    }
+
+  @Command()
   def stop(self,
            name: args.NAME):
     """Stop a DB instance."""


### PR DESCRIPTION
## Describe Changes

Override `delete` in `DuploRDS` so the success message displays only the database name (e.g. `duplojt3103ctl-db deleted`) instead of the full internal slug path (`aws/rds/instance/duplojt3103ctl-db deleted`).

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-42394

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog