### PR TITLE
fix: batch_scheduling_policy update command returns 405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path
+- Fixed `batch_scheduling_policy` resource decorator name colliding with `batch_job`
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 
 ## [0.4.3] - 2026-03-18

--- a/src/duplo_resource/batch_scheduling_policy.py
+++ b/src/duplo_resource/batch_scheduling_policy.py
@@ -1,23 +1,61 @@
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV3
-from duplocloud.commander import Resource
+from duplocloud.errors import DuploError
+from duplocloud.commander import Resource, Command
+import duplocloud.args as args
 
-@Resource("batch_job", scope="tenant")
+@Resource("batch_scheduling_policy", scope="tenant")
 class DuploBatchSchedulingPolicy(DuploResourceV3):
   """Manage AWS Batch Scheduling Policies
 
-  Run batch jobs as a managed service on AWS infrastructure. 
+  Run batch jobs as a managed service on AWS infrastructure.
 
-  Read more docs here: 
+  Read more docs here:
   https://docs.duplocloud.com/docs/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):
-    super().__init__(duplo, 
+    super().__init__(duplo,
                      slug="aws/batchSchedulingPolicy",
                      prefixed=True)
 
   def name_from_body(self, body):
     return body["Name"]
 
-  
+  @Command()
+  def update(self,
+             name: args.NAME = None,
+             body: args.BODY = None,
+             patches: args.PATCHES = None) -> dict:
+    """Update a Batch Scheduling Policy.
+
+    The DuploCloud backend expects PUT to the collection endpoint
+    with the resource identified by the body, not by the URL path.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl batch_scheduling_policy update <name>
+      ```
+
+    Args:
+      name: The name of the scheduling policy to update.
+      body: The scheduling policy body.
+      patches: The patches to apply to the resource.
+
+    Returns:
+      resource: The updated scheduling policy.
+
+    Raises:
+      DuploError: If the scheduling policy could not be updated.
+    """
+    if not name and not body:
+      raise DuploError("Name is required when body is not provided")
+    name = name or self.name_from_body(body)
+    current = self.find(name)
+    if body:
+      current.update(body)
+    if patches:
+      current = self.duplo.jsonpatch(current, patches)
+    current["Name"] = self.prefixed_name(name)
+    response = self.client.put(self.endpoint(), current)
+    return response.json()


### PR DESCRIPTION
## Describe Changes

- Fixed `@Resource("batch_job")` → `@Resource("batch_scheduling_policy")` to resolve a name collision with the real `batch_job` resource (also broke mkdocs command discovery)
- Overrode `update()` to PUT to the collection endpoint (`self.endpoint()`) instead of the named resource path (`self.endpoint(name)`), matching the DuploCloud backend expectation
- Update always fetches the current resource first via `find()`, then merges user-provided body on top, ensuring required fields like `Arn` are always present

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41930

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog