### PR TITLE
fix: cloudfront apply crashes with KeyError on metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `cloudfront apply` crashing with `KeyError: 'metadata'` by overriding `apply` with ID-based create-or-update logic
-- Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` and `apply` to use `Username` and set the correct `State` for create vs update
 - Updated broken links in batch documentation
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path
 - Fixed `batch_scheduling_policy` resource decorator name colliding with `batch_job`
 - Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name
-- Fixed `cloudfront apply` crashing with `KeyError: 'metadata'` by overriding `apply` to resolve the distribution by its `Comment` (CloudFront's logical name) via a find-then-update-or-create flow; `find` now also accepts a `Comment` in addition to a distribution ID
+- Fixed `cloudfront apply` crashing with `KeyError: 'metadata'` by overriding `apply` to resolve the distribution by its `Comment` (CloudFront's logical name) via a find-then-update-or-create flow; `find` now takes separate `name` (Comment) and `id` parameters, mirroring `tenant.find()`
 - Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` to return `Username` and adding an `update` method; the inherited V2 `apply` now drives the find → update/create flow
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 - Fixed `lambda apply` failing with "No lambda functions found" when creating the first lambda in a tenant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `cloudfront apply` crashing with `KeyError: 'metadata'` by overriding `apply` with ID-based create-or-update logic
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 
 ## [0.4.3] - 2026-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path
 - Fixed `batch_scheduling_policy` resource decorator name colliding with `batch_job`
 - Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name
+- Fixed `cloudfront apply` crashing with `KeyError: 'metadata'` by overriding `apply` to resolve the distribution by its `Comment` (CloudFront's logical name) via a find-then-update-or-create flow; `find` now also accepts a `Comment` in addition to a distribution ID
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 - Fixed `lambda apply` failing with "No lambda functions found" when creating the first lambda in a tenant
 - Fixed `service apply` creating instead of updating when V3 find endpoint returns 200 with null body for non-existent services

--- a/src/duplo_resource/cloudfront.py
+++ b/src/duplo_resource/cloudfront.py
@@ -23,30 +23,17 @@ class DuploCloudFront(DuploResourceV3):
     super().__init__(duplo, "aws/cloudFrontDistribution")
 
   def name_from_body(self, body):
-    """Resolve the logical name of a CloudFront distribution.
+    """Return the distribution's ``Comment`` — its logical name.
 
-    CloudFront has no ``Name`` field; the ``Comment`` acts as the
-    human-assigned identifier both in AWS and in DuploCloud. Handles
-    the three shapes ``body`` can take:
-
-      * YAML input:     ``body["DistributionConfig"]["Comment"]``
-      * ``find`` result: ``body["Distribution"]["DistributionConfig"]["Comment"]``
-      * ``list`` item:   ``body["Comment"]`` (flat distribution summary)
+    Unwraps the ``Distribution`` envelope (direct-GET response) and
+    falls through ``DistributionConfig`` when absent (list-item
+    summary) so all three body shapes resolve to the same key.
     """
-    config = body.get("DistributionConfig")
-    if config and config.get("Comment"):
-      return config["Comment"]
-    dist = body.get("Distribution")
-    if dist:
-      config = dist.get("DistributionConfig") or {}
-      if config.get("Comment"):
-        return config["Comment"]
-      if dist.get("Comment"):
-        return dist["Comment"]
-    return body.get("Comment")
+    inner = body.get("Distribution", body)
+    return inner.get("DistributionConfig", inner).get("Comment")
 
   def wait_check(self, distribution_id):
-    status_response = self.find(distribution_id)
+    status_response = self.find(distribution_id=distribution_id)
     status = status_response.get("Distribution", {}).get("Status", "Unknown").lower()
     if status == "deployed":
       return status_response
@@ -56,37 +43,46 @@ class DuploCloudFront(DuploResourceV3):
       raise DuploStillWaiting(f"Timed out waiting for CloudFront {distribution_id} to be deployed.")
 
   @Command()
-  def find(self, distribution_id: args.DISTRIBUTION_ID):
-    """Find a CloudFront distribution by ID or Comment.
+  def find(self,
+           name: args.NAME = None,
+           distribution_id: str = None) -> dict:
+    """Find a CloudFront distribution by Comment (name) or by ID.
 
-    Accepts either an AWS distribution ID (e.g. ``E2QWRUHAPOMQZL``) or
-    the distribution's ``Comment`` (its logical name). The direct GET is
-    attempted first; on a not-found response the list is scanned for a
-    distribution whose ``Comment`` matches.
+    Mirrors the ``tenant.find()`` flow: pass ``distribution_id`` when
+    the AWS distribution ID is known (uses the direct GET endpoint),
+    otherwise pass ``name`` — the distribution's ``Comment``, which
+    acts as CloudFront's logical name. Callers with both values
+    should pass both; ``distribution_id`` takes priority. The CLI
+    only exposes ``name``; ``distribution_id`` is available to
+    Python callers and to ``apply`` when a body carries an ``Id``.
 
     Usage:
       ```sh
-      duploctl cloudfront find <distribution_id_or_comment>
+      duploctl cloudfront find <name>
       ```
 
     Args:
-      distribution_id: The CloudFront distribution ID or Comment.
+      name: The distribution's Comment (logical name).
+      distribution_id: The AWS distribution ID.
 
     Returns:
       dict: The distribution object.
 
     Raises:
-      DuploNotFound: If no distribution matches by ID or Comment.
+      DuploError: If neither ``name`` nor ``distribution_id`` is provided.
+      DuploNotFound: If no distribution matches.
     """
-    try:
-      response = self.client.get(self.endpoint(distribution_id))
-      return response.json()
-    except DuploNotFound:
-      pass
-    for dist in self.list():
-      if self.name_from_body(dist) == distribution_id:
-        return dist
-    raise DuploNotFound(distribution_id, "cloudfront")
+    if not name and not distribution_id:
+      raise DuploError("find requires name or distribution_id")
+    if not distribution_id:
+      prefixed = self.prefixed_name(name)
+      for dist in self.list():
+        if self.name_from_body(dist) in (name, prefixed):
+          distribution_id = dist["Id"]
+          break
+      else:
+        raise DuploNotFound(name, "cloudfront")
+    return self.client.get(self.endpoint(distribution_id)).json()
 
   @Command(model="AmazonCloudFrontRequest")
   def create(self, body: args.BODY):
@@ -270,27 +266,15 @@ class DuploCloudFront(DuploResourceV3):
 
     Returns:
       resource: The created or updated distribution.
-
-    Raises:
-      DuploError: If the body has no ``DistributionConfig.Comment`` to
-        identify the distribution with.
     """
-    name = self.name_from_body(body)
-    if not name:
-      raise DuploError(
-        "CloudFront apply requires DistributionConfig.Comment "
-        "to identify the distribution"
-      )
     try:
-      existing = self.find(name)
+      existing = self.find(name=self.name_from_body(body), distribution_id=body.get("Id"))
     except DuploNotFound:
       return self.create(body)
-    existing_id = (
-      existing.get("Id")
-      or existing.get("Distribution", {}).get("Id")
-    )
-    if existing_id:
-      body["Id"] = existing_id
+    dc = existing["Distribution"]["DistributionConfig"]
+    body["Id"] = existing["Distribution"]["Id"]
+    body["DistributionConfig"]["Comment"] = dc["Comment"]
+    body["DistributionConfig"]["CallerReference"] = dc["CallerReference"]
     return self.update(body)
 
   @Command()
@@ -315,7 +299,7 @@ class DuploCloudFront(DuploResourceV3):
     Raises:
       DuploError: If the distribution could not be found or the status is unavailable.
     """
-    response = self.find(distribution_id)
+    response = self.find(distribution_id=distribution_id)
     status = response.get("Distribution", {}).get("Status")
     if status is None:
       raise DuploError(f"Status not found for CloudFront distribution {distribution_id}")

--- a/src/duplo_resource/cloudfront.py
+++ b/src/duplo_resource/cloudfront.py
@@ -211,6 +211,29 @@ class DuploCloudFront(DuploResourceV3):
     return {"message": f"CloudFront distribution {distribution_id} deleted"}
 
   @Command()
+  def apply(self, body: args.BODY) -> dict:
+    """Apply a CloudFront distribution.
+
+    Create or update a CloudFront distribution. If the body contains
+    an ``Id`` field the distribution is updated, otherwise a new one
+    is created.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl cloudfront apply -f 'cloudfront.yaml'
+      ```
+
+    Args:
+      body: The distribution configuration.
+
+    Returns:
+      resource: The created or updated distribution.
+    """
+    if body.get("Id"):
+      return self.update(body)
+    return self.create(body)
+
+  @Command()
   def get_status(self, distribution_id: args.DISTRIBUTION_ID):
     """Get the current status of a CloudFront distribution.
 

--- a/src/duplo_resource/cloudfront.py
+++ b/src/duplo_resource/cloudfront.py
@@ -1,6 +1,11 @@
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV3
-from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
+from duplocloud.errors import (
+  DuploError,
+  DuploFailedResource,
+  DuploNotFound,
+  DuploStillWaiting,
+)
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -17,6 +22,29 @@ class DuploCloudFront(DuploResourceV3):
   def __init__(self, duplo: DuploCtl):
     super().__init__(duplo, "aws/cloudFrontDistribution")
 
+  def name_from_body(self, body):
+    """Resolve the logical name of a CloudFront distribution.
+
+    CloudFront has no ``Name`` field; the ``Comment`` acts as the
+    human-assigned identifier both in AWS and in DuploCloud. Handles
+    the three shapes ``body`` can take:
+
+      * YAML input:     ``body["DistributionConfig"]["Comment"]``
+      * ``find`` result: ``body["Distribution"]["DistributionConfig"]["Comment"]``
+      * ``list`` item:   ``body["Comment"]`` (flat distribution summary)
+    """
+    config = body.get("DistributionConfig")
+    if config and config.get("Comment"):
+      return config["Comment"]
+    dist = body.get("Distribution")
+    if dist:
+      config = dist.get("DistributionConfig") or {}
+      if config.get("Comment"):
+        return config["Comment"]
+      if dist.get("Comment"):
+        return dist["Comment"]
+    return body.get("Comment")
+
   def wait_check(self, distribution_id):
     status_response = self.find(distribution_id)
     status = status_response.get("Distribution", {}).get("Status", "Unknown").lower()
@@ -29,24 +57,36 @@ class DuploCloudFront(DuploResourceV3):
 
   @Command()
   def find(self, distribution_id: args.DISTRIBUTION_ID):
-    """Find a CloudFront distribution.
+    """Find a CloudFront distribution by ID or Comment.
 
-    Find a CloudFront distribution by its distribution ID.
+    Accepts either an AWS distribution ID (e.g. ``E2QWRUHAPOMQZL``) or
+    the distribution's ``Comment`` (its logical name). The direct GET is
+    attempted first; on a not-found response the list is scanned for a
+    distribution whose ``Comment`` matches.
 
     Usage:
       ```sh
-      duploctl cloudfront find <distribution_id>
+      duploctl cloudfront find <distribution_id_or_comment>
       ```
 
     Args:
-      distribution_id: The CloudFront distribution ID.
+      distribution_id: The CloudFront distribution ID or Comment.
 
     Returns:
-      dict: The service object.
+      dict: The distribution object.
+
+    Raises:
+      DuploNotFound: If no distribution matches by ID or Comment.
     """
-    response = self.client.get(self.endpoint(distribution_id))
-    response.raise_for_status()
-    return response.json()
+    try:
+      response = self.client.get(self.endpoint(distribution_id))
+      return response.json()
+    except DuploNotFound:
+      pass
+    for dist in self.list():
+      if self.name_from_body(dist) == distribution_id:
+        return dist
+    raise DuploNotFound(distribution_id, "cloudfront")
 
   @Command(model="AmazonCloudFrontRequest")
   def create(self, body: args.BODY):
@@ -214,9 +254,11 @@ class DuploCloudFront(DuploResourceV3):
   def apply(self, body: args.BODY) -> dict:
     """Apply a CloudFront distribution.
 
-    Create or update a CloudFront distribution. If the body contains
-    an ``Id`` field the distribution is updated, otherwise a new one
-    is created.
+    Creates the distribution if none exists with the body's ``Comment``,
+    otherwise updates the existing one. The ``Comment`` is CloudFront's
+    logical name; re-applying the same YAML targets the same
+    distribution without requiring a server-assigned ``Id`` to be
+    hand-copied into source control.
 
     Usage: CLI Usage
       ```sh
@@ -228,10 +270,28 @@ class DuploCloudFront(DuploResourceV3):
 
     Returns:
       resource: The created or updated distribution.
+
+    Raises:
+      DuploError: If the body has no ``DistributionConfig.Comment`` to
+        identify the distribution with.
     """
-    if body.get("Id"):
-      return self.update(body)
-    return self.create(body)
+    name = self.name_from_body(body)
+    if not name:
+      raise DuploError(
+        "CloudFront apply requires DistributionConfig.Comment "
+        "to identify the distribution"
+      )
+    try:
+      existing = self.find(name)
+    except DuploNotFound:
+      return self.create(body)
+    existing_id = (
+      existing.get("Id")
+      or existing.get("Distribution", {}).get("Id")
+    )
+    if existing_id:
+      body["Id"] = existing_id
+    return self.update(body)
 
   @Command()
   def get_status(self, distribution_id: args.DISTRIBUTION_ID):


### PR DESCRIPTION
## Describe Changes

- Overrode `apply()` on `DuploCloudFront` since CloudFront uses server-assigned distribution IDs, not names — the inherited V3 `apply()` calls `name_from_body()` which expects `body["metadata"]["name"]`, causing a `KeyError`
- New logic: if body contains `Id` → update, otherwise → create

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41929

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog