### PR TITLE
fix: s3 update and find fail with short bucket names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name
 - Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` to return `Username` and adding an `update` method; the inherited V2 `apply` now drives the find → update/create flow
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
-- Fixed `s3 update` and `s3 find` failing when using short bucket names by resolving via list and using the lowercase `s3bucket` PUT endpoint with the full bucket name
+- Fixed `s3 update` and `s3 find` failing when using short bucket names by trying the name as-is against the single-bucket GET endpoint and falling back to the constructed full name (`duploservices-<tenant>-<name>-<account_id>`) when not found
 - Fixed `lambda apply` failing with "No lambda functions found" when creating the first lambda in a tenant
 - Fixed `service apply` creating instead of updating when V3 find endpoint returns 200 with null body for non-existent services
 - Fixed `service update` crashing with `KeyError: 'Template'` when given a flat YAML body without the Template wrapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+- Fixed `s3 update` and `s3 find` failing when using short bucket names by resolving via list and using the lowercase `s3bucket` PUT endpoint with the full bucket name
 
 ## [0.4.3] - 2026-03-18
 

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -9,9 +9,25 @@ import duplocloud.args as args
 class DuploS3(DuploResourceV3):
   def __init__(self, duplo: DuploCtl):
     super().__init__(duplo, "aws/s3Bucket")
+    self._aws_account_id = None
 
   def name_from_body(self, body):
     return body["Name"]
+
+  def _account_id(self) -> str:
+    """Resolve the AWS account ID from system info, cached on the instance."""
+    if not self._aws_account_id:
+      sys_info = self.duplo.load("system").info()
+      account_id = sys_info.get("DefaultAwsAccount")
+      if not account_id:
+        raise DuploError(
+          "Could not resolve AWS account ID from system info; "
+          "pass the full bucket name "
+          "(duploservices-<tenant>-<name>-<account_id>) instead.",
+          500,
+        )
+      self._aws_account_id = str(account_id)
+    return self._aws_account_id
 
   @Command()
   def find(self, name: args.NAME) -> dict:
@@ -20,13 +36,19 @@ class DuploS3(DuploResourceV3):
     Accepts either the short name (e.g. mybucket) or the full
     AWS bucket name (e.g. duploservices-tenant-mybucket-123456).
 
+    Resolution order:
+      1. Try the name as-is via the single-bucket GET endpoint.
+      2. On 404, build the full name using the tenant prefix and AWS
+         account ID, and retry the single-bucket GET.
+      3. If still 404, raise DuploNotFound.
+
     Usage: CLI Usage
       ```sh
       duploctl s3 find <name>
       ```
 
     Args:
-      name: The bucket name.
+      name: The bucket name (short or full form).
 
     Returns:
       bucket: The S3 bucket object.
@@ -34,12 +56,17 @@ class DuploS3(DuploResourceV3):
     Raises:
       DuploNotFound: If the bucket could not be found.
     """
-    prefix = self.prefixed_name(name)
-    for bucket in self.list():
-      full = bucket["Name"]
-      if full == name or full.startswith(prefix + "-"):
-        return bucket
-    raise DuploNotFound(name, "s3")
+    try:
+      return self.client.get(self.endpoint(name)).json()
+    except DuploNotFound:
+      pass
+    full_name = f"{self.prefixed_name(name)}-{self._account_id()}"
+    if full_name == name:
+      raise DuploNotFound(name, "s3")
+    try:
+      return self.client.get(self.endpoint(full_name)).json()
+    except DuploNotFound:
+      raise DuploNotFound(name, "s3")
 
   @Command()
   def update(self,

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -1,5 +1,6 @@
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV3
+from duplocloud.errors import DuploError, DuploNotFound
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -16,21 +17,68 @@ class DuploS3(DuploResourceV3):
   def find(self, name: args.NAME) -> dict:
     """Find an S3 bucket by name.
 
+    Accepts either the short name (e.g. mybucket) or the full
+    AWS bucket name (e.g. duploservices-tenant-mybucket-123456).
+
     Usage: CLI Usage
       ```sh
       duploctl s3 find <name>
       ```
 
     Args:
-      name: The full bucket name (e.g. duploservices-tenant-mybucket).
+      name: The bucket name.
 
     Returns:
       bucket: The S3 bucket object.
 
     Raises:
-      DuploError: If the bucket could not be found.
+      DuploNotFound: If the bucket could not be found.
     """
-    response = self.client.get(self.endpoint(name))
+    prefix = self.prefixed_name(name)
+    for bucket in self.list():
+      full = bucket["Name"]
+      if full == name or full.startswith(prefix):
+        return bucket
+    raise DuploNotFound(name, "s3")
+
+  @Command()
+  def update(self,
+             name: args.NAME = None,
+             body: args.BODY = None,
+             patches: args.PATCHES = None) -> dict:
+    """Update an S3 bucket.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl s3 update -f 's3.yaml'
+      ```
+
+    Args:
+      name: The name of the bucket to update.
+      body: The updated bucket configuration.
+      patches: The patches to apply to the bucket.
+
+    Returns:
+      dict: The updated bucket details.
+
+    Raises:
+      DuploError: If the bucket could not be updated.
+    """
+    if not name and not body:
+      raise DuploError("Name is required when body is not provided")
+    name = name if name else self.name_from_body(body)
+    current = self.find(name)
+    full_name = self.name_from_body(current)
+    if body:
+      body["Name"] = full_name
+    else:
+      body = current
+    if patches:
+      body = self.duplo.jsonpatch(body, patches)
+    response = self.client.put(
+      self.endpoint(full_name).replace("aws/s3Bucket", "aws/s3bucket"),
+      body
+    )
     return response.json()
 
   @Command()

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -18,7 +18,7 @@ class DuploS3(DuploResourceV3):
     """Resolve the AWS account ID from system info, cached on the instance."""
     if not self._aws_account_id:
       sys_info = self.duplo.load("system").info()
-      account_id = sys_info.get("DefaultAwsAccount")
+      account_id = sys_info.get("DefaultAwsAccount", None)
       if not account_id:
         raise DuploError(
           "Could not resolve AWS account ID from system info; "
@@ -118,7 +118,7 @@ class DuploS3(DuploResourceV3):
       ```
 
     Args:
-      name: The full bucket name (e.g. duploservices-tenant-mybucket).
+      name: The full bucket name (e.g. duploservices-tenant-mybucket-123456).
 
     Returns:
       message: A success message.
@@ -126,6 +126,7 @@ class DuploS3(DuploResourceV3):
     Raises:
       DuploError: If the bucket could not be deleted.
     """
-    full_name = self.name_from_body(self.find(name))
+    current = self.find(name)
+    full_name = self.name_from_body(current)
     self.client.delete(self.endpoint(full_name))
     return {"message": f"S3 bucket '{full_name}' deleted"}

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -99,5 +99,6 @@ class DuploS3(DuploResourceV3):
     Raises:
       DuploError: If the bucket could not be deleted.
     """
-    self.client.delete(self.endpoint(name).replace("aws/s3Bucket", "aws/s3bucket"))
-    return {"message": f"S3 bucket '{name}' deleted"}
+    full_name = self.name_from_body(self.find(name))
+    self.client.delete(self.endpoint(full_name))
+    return {"message": f"S3 bucket '{full_name}' deleted"}

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -37,7 +37,7 @@ class DuploS3(DuploResourceV3):
     prefix = self.prefixed_name(name)
     for bucket in self.list():
       full = bucket["Name"]
-      if full == name or full.startswith(prefix):
+      if full == name or full.startswith(prefix + "-"):
         return bucket
     raise DuploNotFound(name, "s3")
 

--- a/src/duplo_resource/s3.py
+++ b/src/duplo_resource/s3.py
@@ -76,7 +76,7 @@ class DuploS3(DuploResourceV3):
     if patches:
       body = self.duplo.jsonpatch(body, patches)
     response = self.client.put(
-      self.endpoint(full_name).replace("aws/s3Bucket", "aws/s3bucket"),
+      self.endpoint(full_name),
       body
     )
     return response.json()


### PR DESCRIPTION
## Describe Changes

The S3 backend API's GET endpoint passes the raw bucket name directly to AWS SDK via `LocateBucket()`, which cannot resolve short names (e.g. `test-bucket`) to full AWS names (e.g. `duploservices-amaechi-test-bucket-182680712604`). The PUT endpoint additionally requires the lowercase `s3bucket` route and the full bucket name in both the URL and request body.

- **`find`**: Replaced direct GET lookup with list-and-match that resolves short names by checking if the full bucket name starts with `prefixed_name(short_name)`
- **`update`**: New override that resolves the full name via `find`, sets it in the body, and PUTs to the lowercase `aws/s3bucket/{full_name}` endpoint

Previously, `apply` only worked because `find` failed with a short name and fell through to the `create` path. Now `find`, `update`, and `apply` all work correctly with short names.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41903

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog