### PR TITLE
fix: service apply, update, and env commands handle edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+- Fixed `service apply` creating instead of updating when V3 find endpoint returns 200 with null body for non-existent services
+- Fixed `service update` crashing with `KeyError: 'Template'` when given a flat YAML body without the Template wrapper
+- Fixed `service update_env` and `update_labels` crashing when `OtherDockerConfig` is empty
 
 ## [0.4.3] - 2026-03-18
 

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -162,13 +162,19 @@ class DuploService(DuploResourceV2):
     if patches:
       body = self.duplo.jsonpatch(body, patches)
     template = body.get("Template", body)
+    # When body is flat (no Template wrapper), use existing service
+    # state as fallback so we don't overwrite settings with defaults
+    if "Template" not in body:
+      existing = self.find(name).get("Template", {})
+    else:
+      existing = template
     if ((ttags := template.get("AllocationTags", None))
         and not body.get("AllocationTags", None)):
       body["AllocationTags"] = ttags
     if "OtherDockerConfig" not in body:
-      body["OtherDockerConfig"] = template.get("OtherDockerConfig") or "{}"
+      body["OtherDockerConfig"] = existing.get("OtherDockerConfig") or "{}"
     if "AgentPlatform" not in body:
-      body["AgentPlatform"] = template.get("AgentPlatform", 0)
+      body["AgentPlatform"] = existing.get("AgentPlatform", 0)
     self.client.post(self.endpoint("ReplicationControllerChangeAll"), body)
     if self.duplo.wait:
       self._wait(old, body)

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -1,7 +1,7 @@
 import time
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploError, DuploFailedResource, DuploStillWaiting
+from duplocloud.errors import DuploError, DuploFailedResource, DuploNotFound, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 from json import dumps, loads
 import duplocloud.args as args
@@ -114,8 +114,11 @@ class DuploService(DuploResourceV2):
     try:
       endpoint = f"v3/subscriptions/{self.tenant_id}/replicationcontroller/{name}"
       response = self.client.get(endpoint)
+      result = response.json()
+      if not result:
+        raise DuploNotFound(name, self.kind)
       self.duplo.logger.debug(f"Found service {name} using new endpoint.")
-      return response.json()
+      return result
     # catch the DuploError and let super take over if it's just a 404 which means the new endpoint doesn't exist
     except DuploError:
       self.duplo.logger.debug(f"Service {name} not found using new endpoint, falling back to list.")
@@ -158,11 +161,14 @@ class DuploService(DuploResourceV2):
       old["Replicaset"] = self.current_replicaset(name)
     if patches:
       body = self.duplo.jsonpatch(body, patches)
-    if ((ttags := body["Template"].get("AllocationTags", None))
+    template = body.get("Template", body)
+    if ((ttags := template.get("AllocationTags", None))
         and not body.get("AllocationTags", None)):
       body["AllocationTags"] = ttags
-    body["OtherDockerConfig"] = body["Template"]["OtherDockerConfig"]
-    body["AgentPlatform"] = body["Template"].get("AgentPlatform", 0)
+    if "OtherDockerConfig" not in body:
+      body["OtherDockerConfig"] = template.get("OtherDockerConfig") or "{}"
+    if "AgentPlatform" not in body:
+      body["AgentPlatform"] = template.get("AgentPlatform", 0)
     self.client.post(self.endpoint("ReplicationControllerChangeAll"), body)
     if self.duplo.wait:
       self._wait(old, body)
@@ -409,7 +415,8 @@ class DuploService(DuploResourceV2):
       return "mixed"
 
     service = self.find(name)
-    currentDockerconfig = loads(service["Template"]["OtherDockerConfig"])
+    raw_config = service["Template"].get("OtherDockerConfig") or "{}"
+    currentDockerconfig = loads(raw_config)
     currentEnv = currentDockerconfig.get("Env", [])
     # Check if user is attempting to merge against a null Env. If so, set currentEnv to empty.
     if currentEnv is None and strategy == "merge":
@@ -485,7 +492,8 @@ class DuploService(DuploResourceV2):
       message: A message about success.
     """
     service = self.find(name)
-    currentDockerconfig = loads(service["Template"]["OtherDockerConfig"])
+    raw_config = service["Template"].get("OtherDockerConfig") or "{}"
+    currentDockerconfig = loads(raw_config)
     currentLabels = currentDockerconfig.get("PodLabels", [])
     newLabels = []
     if setvar is not None:

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from unittest.mock import ANY
 from duplo_resource.service import DuploService
-from duplocloud.errors import DuploError
+from duplocloud.errors import DuploError, DuploNotFound
 
 @pytest.mark.unit
 def test_create_service(mocker):
@@ -116,3 +116,89 @@ def test_list_pods(mocker):
 
     # does not belong to a duplo service, gets filtered out
     assert service.pods(target_service) == []
+
+
+@pytest.mark.unit
+def test_find_raises_not_found_on_null_response(mocker):
+  """V3 find endpoint returns 200 with null body for non-existent services."""
+  mock_client = mocker.MagicMock()
+  mock_client.load_client.return_value = mock_client
+  service = DuploService(mock_client)
+  mock_response = mocker.MagicMock()
+  mock_response.json.return_value = None
+  mock_client.get.return_value = mock_response
+  # The fallback to super().find() should also fail for a missing service
+  mocker.patch.object(
+    DuploService.__bases__[0], 'find',
+    side_effect=DuploNotFound("test-svc", "Service")
+  )
+  with pytest.raises(DuploNotFound):
+    service.find("test-svc")
+
+
+@pytest.mark.unit
+def test_update_with_flat_yaml_body(mocker):
+  """update() handles flat YAML body without Template wrapper."""
+  mock_client = mocker.MagicMock()
+  mock_client.load_client.return_value = mock_client
+  mock_client.wait = False
+  service = DuploService(mock_client)
+  existing_service = {
+    "Name": "test-svc",
+    "Template": {
+      "OtherDockerConfig": '{"Env":[]}',
+      "AgentPlatform": 7,
+      "AllocationTags": "tagA",
+    }
+  }
+  mocker.patch.object(service, 'find', return_value=existing_service)
+  flat_body = {"Name": "test-svc", "Image": "nginx:latest", "Replicas": 2}
+  service.update("test-svc", body=flat_body)
+  posted_body = mock_client.post.call_args[0][1]
+  assert posted_body["OtherDockerConfig"] == '{"Env":[]}'
+  assert posted_body["AgentPlatform"] == 7
+
+
+@pytest.mark.unit
+def test_update_with_template_wrapped_body(mocker):
+  """update() handles standard Template-wrapped body from API response."""
+  mock_client = mocker.MagicMock()
+  mock_client.load_client.return_value = mock_client
+  mock_client.wait = False
+  service = DuploService(mock_client)
+  wrapped_body = {
+    "Name": "test-svc",
+    "Template": {
+      "OtherDockerConfig": '{"Env":[{"Name":"X","Value":"1"}]}',
+      "AgentPlatform": 3,
+    }
+  }
+  service.update("test-svc", body=wrapped_body)
+  posted_body = mock_client.post.call_args[0][1]
+  assert posted_body["OtherDockerConfig"] == \
+    '{"Env":[{"Name":"X","Value":"1"}]}'
+  assert posted_body["AgentPlatform"] == 3
+
+
+@pytest.mark.unit
+def test_update_env_empty_otherdockerconfig(mocker):
+  """update_env() handles empty string OtherDockerConfig."""
+  mock_client = mocker.MagicMock()
+  mock_client.load_client.return_value = mock_client
+  mock_client.wait = False
+  service = DuploService(mock_client)
+  service_with_empty_config = {
+    "Name": "test-svc",
+    "Template": {
+      "OtherDockerConfig": "",
+      "AllocationTags": "",
+    }
+  }
+  mocker.patch.object(service, 'find', return_value=service_with_empty_config)
+  service.update_env(
+    "test-svc", setvar=[("MY_VAR", "val")],
+    strategy="replace", deletevar=None
+  )
+  posted_body = mock_client.post.call_args[0][1]
+  config = json.loads(posted_body["OtherDockerConfig"])
+  assert config["Env"] == [{"Name": "MY_VAR", "Value": "val"}]


### PR DESCRIPTION
## Describe Changes

Three related fixes in the service resource:

- **`find`**: The V3 `replicationcontroller/{name}` endpoint returns HTTP 200 with a null body for non-existent services. This caused `apply` to take the update path instead of create. Now checks for a null/empty response and raises `DuploNotFound`.
- **`update`**: Crashes with `KeyError: 'Template'` when given a flat YAML body (e.g. from `apply`). Now uses `body.get("Template", body)` to handle both API response format (nested Template) and user YAML (flat).
- **`update_env` / `update_labels`**: Crash with `JSONDecodeError` when `OtherDockerConfig` is empty string. Now defaults to `"{}"`.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41899

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog