### PR TITLE
fix: override name_from_body in user resource to use Username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `user apply` failing with `KeyError: 'Name'` because the user resource identifies by `Username` not `Name`
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 
 ## [0.4.3] - 2026-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path
 - Fixed `batch_scheduling_policy` resource decorator name colliding with `batch_job`
 - Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name
+- Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` to return `Username` and adding an `update` method; the inherited V2 `apply` now drives the find → update/create flow
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 - Fixed `lambda apply` failing with "No lambda functions found" when creating the first lambda in a tenant
 - Fixed `service apply` creating instead of updating when V3 find endpoint returns 200 with null body for non-existent services

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `user apply` failing with `KeyError: 'Name'` because the user resource identifies by `Username` not `Name`
+- Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` and `apply` to use `Username` and set the correct `State` for create vs update
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
 
 ## [0.4.3] - 2026-03-18

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -13,6 +13,39 @@ class DuploUser(DuploResourceV2):
   def name_from_body(self, body):
     return body["Username"]
 
+  @Command()
+  def apply(self,
+            body: args.BODY,
+            wait: args.WAIT = False) -> dict:
+    """Apply a user.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl user apply -f 'user.yaml'
+      ```
+      Contents of the `user.yaml` file
+      ```yaml
+      --8<-- "src/tests/data/user.yaml"
+      ```
+
+    Args:
+      body: The user body.
+      wait: Wait for the user to be applied.
+
+    Returns:
+      message: A success message.
+    """
+    name = self.name_from_body(body)
+    try:
+      self.find(name)
+      if 'State' not in body:
+        body['State'] = 'updated'
+    except DuploNotFound:
+      if 'State' not in body:
+        body['State'] = 'added'
+    response = self.client.post("admin/UpdateUserRole", body)
+    return response.json()
+
   @Command("ls")
   def list(self):
     """Retrieve a list of all users in the Duplo system."""

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -10,6 +10,9 @@ class DuploUser(DuploResourceV2):
     super().__init__(duplo)
     self.tenent_svc = duplo.load('tenant')
 
+  def name_from_body(self, body):
+    return body["Username"]
+
   @Command("ls")
   def list(self):
     """Retrieve a list of all users in the Duplo system."""

--- a/src/duplo_resource/user.py
+++ b/src/duplo_resource/user.py
@@ -13,56 +13,23 @@ class DuploUser(DuploResourceV2):
   def name_from_body(self, body):
     return body["Username"]
 
-  @Command()
-  def apply(self,
-            body: args.BODY,
-            wait: args.WAIT = False) -> dict:
-    """Apply a user.
-
-    Usage: CLI Usage
-      ```sh
-      duploctl user apply -f 'user.yaml'
-      ```
-      Contents of the `user.yaml` file
-      ```yaml
-      --8<-- "src/tests/data/user.yaml"
-      ```
-
-    Args:
-      body: The user body.
-      wait: Wait for the user to be applied.
-
-    Returns:
-      message: A success message.
-    """
-    name = self.name_from_body(body)
-    try:
-      self.find(name)
-      if 'State' not in body:
-        body['State'] = 'updated'
-    except DuploNotFound:
-      if 'State' not in body:
-        body['State'] = 'added'
-    response = self.client.post("admin/UpdateUserRole", body)
-    return response.json()
-
   @Command("ls")
   def list(self):
     """Retrieve a list of all users in the Duplo system."""
     response = self.client.get("admin/GetAllUserRoles")
     return response.json()
-  
+
   @Command("get")
-  def find(self, 
+  def find(self,
            name: args.NAME):
     """Find a User by their username."""
     try:
       return [u for u in self.list() if u["Username"] == name][0]
     except IndexError:
       raise DuploNotFound(name, "User")
-  
+
   @Command()
-  def create(self, 
+  def create(self,
              body: args.BODY) -> dict:
     """Create a new user.
 
@@ -74,15 +41,39 @@ class DuploUser(DuploResourceV2):
       ```yaml
       --8<-- "src/tests/data/user.yaml"
       ```
-    
+
     Args:
-      body: The user body. 
+      body: The user body.
 
     Returns:
       message: A success message.
     """
     if 'State' not in body:
       body['State'] = 'added'
+    response = self.client.post("admin/UpdateUserRole", body)
+    return response.json()
+
+  @Command()
+  def update(self,
+             name: args.NAME = None,
+             body: args.BODY = None) -> dict:
+    """Update an existing user.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl user update -f 'user.yaml'
+      ```
+
+    Args:
+      name: The username (unused; kept for signature parity with the
+        base ``apply`` which calls ``update(name, body)`` positionally).
+      body: The user body.
+
+    Returns:
+      message: A success message.
+    """
+    if 'State' not in body:
+      body['State'] = 'updated'
     response = self.client.post("admin/UpdateUserRole", body)
     return response.json()
   


### PR DESCRIPTION
## Describe Changes

`duploctl user apply` fails with `KeyError: 'Name'` because the inherited `DuploResourceV2.apply()` calls `name_from_body(body)` which expects a `Name` key, but the user resource uses `Username` as its identifier field.

Overrides `name_from_body()` in `DuploUser` to return `body["Username"]`.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41892

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog