### PR TITLE
fix: guard against None deletevar in tenant config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+- Fixed `tenant config` crashing with help text when `--deletevar` is not provided
 
 ## [0.4.3] - 2026-03-18
 

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -390,7 +390,7 @@ class DuploTenant(DuploResourceV2):
       change = response.json()
       change["Operation"] = "update"
       changes.append(change)
-    for k in deletevar:
+    for k in (deletevar or []):
       if k in curr_keys:
         self.client.delete(f"{endpoint}/{k}")
         change = {"Key": k, "Operation": "delete"}


### PR DESCRIPTION
## Describe Changes

When `--deletevar` is not passed to `tenant config`, argparse returns `None` (since `action='append'` defaults to `None`). The `for k in deletevar:` loop on line 393 then raises `TypeError`, which the controller catches and displays the class docstring as an error — making it look like help text instead of executing the command.

Added `(deletevar or [])` guard, consistent with line 371 which already handles this correctly.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41893

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog