### PR TITLE
fix: use ModifyRDSDBInstance endpoint for RDS modify commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+- Fixed `rds retention_period`, `rds iam_auth`, and `rds final_snapshot` failing with JSON decode error by using the correct `ModifyRDSDBInstance` endpoint
 
 ## [0.4.3] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `service update_image` now uses the V3 containerimage endpoint and supports updating main, sidecar, and init container images in a single call
+- `rds` exposes a `modify` command wrapping the `ModifyRDSDBInstance` endpoint; `set_monitor_interval`, `iam_auth`, `final_snapshot`, and `retention_period` now delegate to it
 
 ### Fixed
 

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -163,23 +163,50 @@ class DuploRDS(DuploResourceV3):
     }
   
   @Command()
+  def modify(self,
+             name: args.NAME,
+             body: args.BODY) -> dict:
+    """Modify a DB instance via the ModifyRDSDBInstance endpoint.
+
+    Sends an arbitrary request body to the AWS ModifyRDSDBInstance API
+    for the named DB instance. Used internally by higher-level commands
+    like iam_auth, final_snapshot, and retention_period.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl rds modify <name> -f payload.yaml
+      ```
+
+    Args:
+      name: The name of the DB instance to modify.
+      body: The ModifyRDSDBInstance request body.
+
+    Returns:
+      message: A success message.
+    """
+    body["DBInstanceIdentifier"] = name
+    self.client.post(
+      f"subscriptions/{self.tenant_id}/ModifyRDSDBInstance", body
+    )
+    return {
+      "message": f"DB instance {name} modified"
+    }
+
+  @Command()
   def set_monitor_interval(self,
                            name: args.NAME,
                            interval: args.INTERVAL,
                            immediate: args.IMMEDIATE=False):
     """Set the monitoring interval for a DB instance.
-    
+
     Args:
       name (str): The name of the DB instance to update.
       interval (str): The new monitoring interval to use for the DB instance.
     """
-    tenant_id = self.tenant["TenantId"]
-    body = {
-      "DBInstanceIdentifier": name,
-      "ApplyImmediately": immediate, 
-      "MonitoringInterval":interval
-    }
-    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
+    self.modify(name=name, body={
+      "ApplyImmediately": immediate,
+      "MonitoringInterval": interval
+    })
     return {
       "message": f"Monitoring interval for DB instance {name} set to {interval}"
     }
@@ -200,30 +227,24 @@ class DuploRDS(DuploResourceV3):
                enable: args.ENABLE,
                immediate: args.IMMEDIATE=False):
     """Toggle IAM authentication for a DB instance."""
-    body = {
-      "DBInstanceIdentifier": name,
+    self.modify(name=name, body={
       "EnableIAMDatabaseAuthentication": enable,
       "ApplyImmediately": immediate
-    }
-    tenant_id = self.tenant["TenantId"]
-    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
+    })
     return {
       "message": f"IAM authentication for DB instance {name} is {enable}"
     }
-  
+
   @Command()
   def final_snapshot(self,
                      name: args.NAME,
                      enable: args.ENABLE,
                      immediate: args.IMMEDIATE=False):
     """Toggle final snapshot for a DB instance."""
-    body = {
-      "DBInstanceIdentifier": name,
+    self.modify(name=name, body={
       "SkipFinalSnapshot": not enable,
       "ApplyImmediately": immediate
-    }
-    tenant_id = self.tenant["TenantId"]
-    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
+    })
     return {
       "message": f"Final Snapshot for DB instance {name} is {enable}"
     }
@@ -260,13 +281,10 @@ class DuploRDS(DuploResourceV3):
                        days: args.DAYS,
                        immediate: args.IMMEDIATE=False):
     """Set the retention period for a DB instance."""
-    body = {
-      "DBInstanceIdentifier": name,
+    self.modify(name=name, body={
       "BackupRetentionPeriod": days,
       "ApplyImmediately": immediate
-    }
-    tenant_id = self.tenant["TenantId"]
-    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
+    })
     return {
       "message": f"DB instance {name} retention period set to {days} days"
     }

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -181,7 +181,8 @@ class DuploRDS(DuploResourceV3):
       "EnableIAMDatabaseAuthentication": enable,
       "ApplyImmediately": immediate
     }
-    self.update(name=name, body=body)
+    tenant_id = self.tenant["TenantId"]
+    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
     return {
       "message": f"IAM authentication for DB instance {name} is {enable}"
     }
@@ -191,13 +192,14 @@ class DuploRDS(DuploResourceV3):
                      name: args.NAME,
                      enable: args.ENABLE,
                      immediate: args.IMMEDIATE=False):
-    """Toggle IAM authentication for a DB instance."""
+    """Toggle final snapshot for a DB instance."""
     body = {
       "DBInstanceIdentifier": name,
       "SkipFinalSnapshot": not enable,
       "ApplyImmediately": immediate
     }
-    self.update(name=name, body=body)
+    tenant_id = self.tenant["TenantId"]
+    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
     return {
       "message": f"Final Snapshot for DB instance {name} is {enable}"
     }
@@ -239,7 +241,8 @@ class DuploRDS(DuploResourceV3):
       "BackupRetentionPeriod": days,
       "ApplyImmediately": immediate
     }
-    self.update(name=name, body=body)
+    tenant_id = self.tenant["TenantId"]
+    self.client.post(f"subscriptions/{tenant_id}/ModifyRDSDBInstance", body)
     return {
       "message": f"DB instance {name} retention period set to {days} days"
     }


### PR DESCRIPTION
## Describe Changes

`retention_period`, `iam_auth`, and `final_snapshot` were using the generic V3 `update()` method, which does a PUT to the V3 RDS endpoint and calls `response.json()` on the result. The `ModifyRDSDBInstance` API returns an empty response body, causing a JSON decode error.

Changed all three commands to use `self.client.post(subscriptions/{tenant_id}/ModifyRDSDBInstance, body)` directly — matching the existing pattern used by `set_monitor_interval`.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41909

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog