### PR TITLE
fix: lambda apply fails when tenant has no lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `apply` failing for resources whose API returns HTTP 400 (not 404) for not-found lookups (e.g. RDS) by promoting 400 responses containing "not found" to `DuploNotFound`
+- Fixed `lambda apply` failing with "No lambda functions found" when creating the first lambda in a tenant
 
 ## [0.4.3] - 2026-03-18
 

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -1,6 +1,6 @@
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploError, DuploNotFound
+from duplocloud.errors import DuploNotFound
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -29,12 +29,8 @@ class DuploLambda(DuploResourceV2):
       list: A list of all lambdas in the current subscription.
     """
     tenant_id = self.tenant["TenantId"]
-    tenant_name = self.tenant["AccountName"]
     response = self.client.get(f"subscriptions/{tenant_id}/GetLambdaFunctions")
-    if (data := response.json()):
-      return data
-    else:
-      raise DuploError(f"No lambda functions found in tenant '{tenant_name}'", 404)
+    return response.json() or []
   
   @Command()
   def find(self, 

--- a/src/duplo_resource/lambda.py
+++ b/src/duplo_resource/lambda.py
@@ -1,6 +1,6 @@
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploNotFound
+from duplocloud.errors import DuploNotFound, DuploStillWaiting
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 
@@ -76,7 +76,10 @@ class DuploLambda(DuploResourceV2):
     """
     def wait_check():
       name = self.name_from_body(body)
-      self.find(name)
+      try:
+        self.find(name)
+      except DuploNotFound:
+        raise DuploStillWaiting(f"Waiting for Lambda '{name}' to become visible")
     tenant_id = self.tenant["TenantId"]
     self.client.post(f"subscriptions/{tenant_id}/CreateLambdaFunction", body)
     if self.duplo.wait:


### PR DESCRIPTION
## Describe Changes

`lambda list()` raised a generic `DuploError` when the API returned an empty list. The V2 `apply()` only catches `DuploNotFound` to determine create-vs-update, so the error propagated instead of falling through to `create()`.

Changed `list()` to return `[]` instead of raising, so `find()` naturally raises `DuploNotFound` via the `IndexError` path and `apply()` correctly routes to `create()`.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-42520

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog