### PR TITLE
fix: update broken batch documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated broken links in batch documentation
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path
 - Fixed `batch_scheduling_policy` resource decorator name colliding with `batch_job`
 - Fixed `rds delete` showing internal AWS path (`aws/rds/instance/<name>`) instead of only the database name

--- a/src/duplo_resource/batch_compute.py
+++ b/src/duplo_resource/batch_compute.py
@@ -11,7 +11,7 @@ class DuploBatchCompute(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_definition.py
+++ b/src/duplo_resource/batch_definition.py
@@ -11,7 +11,7 @@ class DuploBatchDefinition(DuploResourceV3):
   Manage batch Job Definitions as a resource in Duplo.
 
   Read more docs here:
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_job.py
+++ b/src/duplo_resource/batch_job.py
@@ -11,7 +11,7 @@ class DuploBatchJob(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_queue.py
+++ b/src/duplo_resource/batch_queue.py
@@ -11,7 +11,7 @@ class DuploBatchQueue(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure. 
 
   Read more docs here: 
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):

--- a/src/duplo_resource/batch_scheduling_policy.py
+++ b/src/duplo_resource/batch_scheduling_policy.py
@@ -11,7 +11,7 @@ class DuploBatchSchedulingPolicy(DuploResourceV3):
   Run batch jobs as a managed service on AWS infrastructure.
 
   Read more docs here:
-  https://docs.duplocloud.com/docs/overview/aws-services/batch
+  https://docs.duplocloud.com/docs/automation-platform/overview/aws-services/batch
   """
 
   def __init__(self, duplo: DuploCtl):


### PR DESCRIPTION
## Summary

- Updated batch docs URL in all five batch resource files (`batch_compute`, `batch_definition`, `batch_job`, `batch_queue`, `batch_scheduling_policy`) from `/docs/overview/aws-services/batch` to `/docs/automation-platform/overview/aws-services/batch`
- Added CHANGELOG entry

Replaces #234 (original PR author no longer at company).

## Test plan

- [ ] Verify updated URLs resolve correctly in browser
- [ ] No code logic changes — documentation strings only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)