### PR TITLE
docs(asg,ecs): fix incorrect CLI examples and add missing Usage blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `asg create` docstring showing `duploctl hosts create` instead of `duploctl asg create`
+- Fixed `asg scale` docstring advertising a non-existent `-n <name>` flag; `name` is a positional argument
+- Fixed `ecs list_task_def_family` docstring referencing a non-existent `list_definitions` command
+- Added missing `Usage: CLI Usage` blocks to all remaining `ecs` commands without one (`create_service`, `update_service`, `update_taskdef`, `delete_service`, `find_def`, `find_def_by_arn`, `find_service_family`, `find_task_def_family`) so the generated docs show how to invoke them
 - Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` and `apply` to use `Username` and set the correct `State` for create vs update
 - Updated broken links in batch documentation
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -70,7 +70,7 @@ class DuploAsg(DuploResourceV2):
     
     Usage: CLI Usage
       ```sh
-      duploctl hosts create -f 'asg.yaml'
+      duploctl asg create -f 'asg.yaml'
       ```
       Contents of the `asg.yaml` file
       ```yaml
@@ -184,11 +184,11 @@ class DuploAsg(DuploResourceV2):
 
     Usage: CLI Usage
       ```sh
-      duploctl asg scale -n <name> [-m <min>] [-M <max>]
+      duploctl asg scale <name> [-m <min>] [-M <max>]
       ```
-    
+
     Args:
-      name: The  name of the ASG to scale.
+      name: The name of the ASG to scale (positional).
       min: The new minimum number of instances the ASG should maintain. Use -m flag to set.
       max: The new maximum number of instances the ASG can scale to. Use -M flag to set.
 

--- a/src/duplo_resource/ecs_service.py
+++ b/src/duplo_resource/ecs_service.py
@@ -81,8 +81,13 @@ class DuploEcsService(DuploResourceV2):
   def find_service_family(self,
                           name: args.NAME):
     """Find Service Family by Name
-    
+
     Find an ECS Services task definition family by name.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs find_service_family <name>
+      ```
 
     Args:
       name: The name of the ECS task definition to find.
@@ -101,7 +106,14 @@ class DuploEcsService(DuploResourceV2):
   @Command()
   def delete_service(self,
                      name: args.NAME) -> dict:
-    """Delete an ECS service.
+    """Delete an ECS Service.
+
+    Delete an ECS service by name.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs delete_service <name>
+      ```
 
     Args:
       name: The name of the ECS service to delete.
@@ -120,10 +132,9 @@ class DuploEcsService(DuploResourceV2):
 
     Retrieve a list of all ECS task definitions in a tenant.
 
-    Example:
-      CLI usage
+    Usage: CLI Usage
       ```sh
-      duploctl ecs list_definitions
+      duploctl ecs list_task_def_family
       ```
 
     Returns:
@@ -138,6 +149,11 @@ class DuploEcsService(DuploResourceV2):
   def find_def(self,
                name: args.NAME):
     """Find the latest version of an ECS task definition by family name.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs find_def <name>
+      ```
 
     Args:
       name: The family name of the ECS task definition to find.
@@ -160,6 +176,11 @@ class DuploEcsService(DuploResourceV2):
 
     Find a task definition by its AWS ARN.
 
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs find_def_by_arn <arn>
+      ```
+
     Args:
       arn: The ARN of the ECS task definition to find.
 
@@ -177,6 +198,11 @@ class DuploEcsService(DuploResourceV2):
   def find_task_def_family(self,
                            name: args.NAME):
     """Find a ECS task definition family by name.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs find_task_def_family <name>
+      ```
 
     Args:
       name: The name of the ECS task definition to find.
@@ -198,6 +224,11 @@ class DuploEcsService(DuploResourceV2):
                      body: args.BODY) -> dict:
     """Create an ECS service.
 
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs create_service -f 'ecs_service.yaml'
+      ```
+
     Args:
       body: The ECS service definition object.
 
@@ -215,6 +246,11 @@ class DuploEcsService(DuploResourceV2):
   def update_service(self,
              body: args.BODY) -> dict:
     """Update an ECS service.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs update_service -f 'ecs_service.yaml'
+      ```
 
     Args:
       body: The updated ECS service object.
@@ -236,6 +272,11 @@ class DuploEcsService(DuploResourceV2):
 
     Updates a task definition. This creates a new revision of the task definition and returns the new ARN.
     Note each definition is immutable so this is effectively a create operation for one item in a set and the latest one is the active one.
+
+    Usage: CLI Usage
+      ```sh
+      duploctl ecs update_taskdef -f 'ecs_td.yaml'
+      ```
 
     Args:
       body: The updated ECS task definition object.


### PR DESCRIPTION
## Describe Changes

Resource-specific docstring fixes for the `asg` and `ecs` resources. Scope deliberately excludes the shared template-mechanism issue (where inherited V2/V3 docstrings render the wrong CLI name for some resources) — that's a follow-up PR.

### asg
- `create` docstring showed `duploctl hosts create` — corrected to `duploctl asg create`.
- `scale` docstring advertised a non-existent `-n <name>` flag (customer got `unrecognized arguments: -n`). Updated to positional usage.

### ecs
Audited every `@Command` in `ecs_service.py`; 8 of 14 had no `Usage: CLI Usage` block. Added blocks for `create_service`, `update_service`, `update_taskdef`, `delete_service`, `find_def`, `find_def_by_arn`, `find_service_family`, and `find_task_def_family`.

Also caught a latent bug: `list_task_def_family` referenced a non-existent `duploctl ecs list_definitions` command in its example. Fixed to use the actual method name.

Docs-only change — no code behavior changed, so no new tests. Verified `mkdocs build` emits no new griffe warnings for the touched files, and the existing unit tests for `asg`/`ecs` still pass.

## Link to Issues

- https://app.clickup.com/t/8655600/DUPLO-31494 (asg create part)
- https://app.clickup.com/t/8655600/DUPLO-31496 (asg scale)
- https://app.clickup.com/t/8655600/DUPLO-31816 (ecs apply/find docs)
- https://app.clickup.com/t/8655600/DUPLO-32937 (ecs missing commands in docs)

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests — N/A, docs-only change
- [x] Make sure to note changes in Changelog