### PR TITLE
docs: use entry-point name in auto-generated CLI examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed auto-generated CLI usage examples in the docs rendering the wrong command name for resources whose class name differs from the entry-point name. The base `DuploResourceV2`/`DuploResourceV3` docstrings now use `{{command}}` (the entry-point name) instead of `{{kind | lower}}` (derived from the class name). Affects `aws_secret` (was `awssecret`), `ssm_param` (was `param`), `pvc` (was `persistentvolumeclaim`), and `ecs` (was `ecsservice`).
 - Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` and `apply` to use `Username` and set the correct `State` for create vs update
 - Updated broken links in batch documentation
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path

--- a/scripts/mkdocs.py
+++ b/scripts/mkdocs.py
@@ -106,7 +106,7 @@ def gen_resource_page(endpoint: str):
   command_opts = member_opts + "\n      is_command: true"
 
   with open(fp, 'w') as f:
-    f.write(f"---\nkind: {kind}\n---\n")
+    f.write(f"---\nkind: {kind}\ncommand: {resource_name}\n---\n")
     f.write(f"::: {ref}\n    options:\n      members: false\n      inherited_members: false\n\n")
     if command_methods:
       f.write("## Commands\n\n")

--- a/src/duplocloud/resource.py
+++ b/src/duplocloud/resource.py
@@ -111,7 +111,7 @@ class DuploResourceV2(DuploResource):
     
     Usage: cli usage
       ```sh
-      duploctl {{kind | lower}} list
+      duploctl {{command}} list
       ```
 
     Returns:
@@ -126,7 +126,7 @@ class DuploResourceV2(DuploResource):
 
     Usage: cli usage
       ```sh
-      duploctl {{kind | lower}} find <name>
+      duploctl {{command}} find <name>
       ```
     
     Args:
@@ -182,7 +182,7 @@ class DuploResourceV3(DuploResource):
 
     Usage: cli usage
       ```sh
-      duploctl {{kind | lower}} list
+      duploctl {{command}} list
       ```
     
     Returns:
@@ -198,7 +198,7 @@ class DuploResourceV3(DuploResource):
 
     Usage: cli usage
       ```sh
-      duploctl {{kind | lower}} find <name>
+      duploctl {{command}} find <name>
       ```
 
     Args:
@@ -221,7 +221,7 @@ class DuploResourceV3(DuploResource):
 
     Usage: cli usage
       ```sh
-      duploctl {{kind | lower}} delete <name>
+      duploctl {{command}} delete <name>
       ```
 
     Args:
@@ -247,7 +247,7 @@ class DuploResourceV3(DuploResource):
 
     Usage: CLI Usage
       ```sh
-      duploctl {{kind | lower}} create -f '{{kind | lower}}.yaml'
+      duploctl {{command}} create -f '{{kind | lower}}.yaml'
       ```
       Contents of the `{{kind|lower}}.yaml` file
       ```yaml
@@ -258,7 +258,7 @@ class DuploResourceV3(DuploResource):
       ```sh
       echo \"\"\"
       --8<-- "src/tests/data/{{kind|lower}}.yaml"
-      \"\"\" | duploctl {{kind | lower}} create -f -
+      \"\"\" | duploctl {{command}} create -f -
       ```
 
     Args:
@@ -321,7 +321,7 @@ class DuploResourceV3(DuploResource):
 
     Usage: CLI Usage
       ```sh
-      duploctl {{kind | lower}} apply -f '{{kind | lower}}.yaml'
+      duploctl {{command}} apply -f '{{kind | lower}}.yaml'
       ```
       Contents of the `{{kind|lower}}.yaml` file
       ```yaml


### PR DESCRIPTION
## Describe Changes

Auto-generated resource doc pages used the class-name-derived kind (e.g., `awssecret` for `DuploAwsSecret`) when rendering CLI usage examples, instead of the actual entry-point command name (`aws_secret`). Four resources shipped docs telling customers to run non-existent commands:

| Class | Template rendered | Correct command |
|---|---|---|
| `DuploAwsSecret` | `awssecret` | `aws_secret` |
| `DuploParam` | `param` | `ssm_param` |
| `DuploEcsService` | `ecsservice` | `ecs` |
| `PersistentVolumeClaim` | `persistentvolumeclaim` | `pvc` |

### Fix

- `scripts/mkdocs.py` now emits `command: <entry-point-name>` in each generated page's frontmatter, alongside the existing `kind:` field.
- Base `DuploResourceV2`/`DuploResourceV3` docstrings for `list`/`find`/`delete`/`create`/`apply` now render CLI examples as `duploctl {{command}} <sub>` instead of `duploctl {{kind | lower}} <sub>`.

`{{kind | lower}}` references used for `.yaml` test-data file paths (e.g., `src/tests/data/awssecret.yaml`) were intentionally left alone since they match existing file names.

Docs-only change; verified with `mkdocs build` that the rendered HTML for all four affected pages now shows the correct CLI command and no occurrences of the old wrong names.

## Link to Issues

- https://app.clickup.com/t/8655600/DUPLO-33001 (aws_secret)
- https://app.clickup.com/t/8655600/DUPLO-31494 (pvc part)
- https://app.clickup.com/t/8655600/DUPLO-31816 (ecs)

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog