### PR TITLE
fix(ecs): validate --container-image names against task definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `ecs update_image --container-image` silently registering an unchanged task-definition revision (and triggering a service rollout) when the supplied container name did not exist; it now raises with the list of valid container names
 - Fixed `user apply` failing with `KeyError: 'Name'` by overriding `name_from_body` and `apply` to use `Username` and set the correct `State` for create vs update
 - Updated broken links in batch documentation
 - Fixed `batch_scheduling_policy update` returning 405 by PUTting to the collection endpoint instead of a named resource path

--- a/src/duplo_resource/ecs_service.py
+++ b/src/duplo_resource/ecs_service.py
@@ -292,6 +292,14 @@ class DuploEcsService(DuploResourceV2):
     tdf = self.find_def(name)
     if container_image:
       container_updates = dict(container_image)
+      known_names = [c.get("Name") for c in tdf.get("ContainerDefinitions", []) if c.get("Name")]
+      unknown = [n for n in container_updates if n not in known_names]
+      if unknown:
+        raise DuploError(
+          f"Container name(s) not found in task definition '{name}': {unknown}. "
+          f"Available containers: {known_names}",
+          404,
+        )
       for container_def in tdf["ContainerDefinitions"]:
         if container_def["Name"] in container_updates:
           container_def["Image"] = container_updates[container_def["Name"]]

--- a/src/tests/test_ecs_service.py
+++ b/src/tests/test_ecs_service.py
@@ -74,6 +74,34 @@ def test_update_image_without_container(mocker):
     assert_response(result, "ECS Service and Task Definition updated successfully.")
 
 @pytest.mark.unit
+def test_update_image_unknown_container_raises_and_does_not_mutate(mocker):
+    mock_client = mocker.MagicMock()
+    service = DuploEcsService(mock_client)
+    mock_task_def = {
+        "ContainerDefinitions": [
+            {"Name": "app", "Image": "old-image:1"},
+            {"Name": "sidecar", "Image": "sidecar:1"}
+        ]
+    }
+    mocker.patch.object(service, 'prefixed_name', return_value="test-service")
+    mocker.patch.object(service, 'find_def', return_value=mock_task_def)
+    mocker.patch.object(service, 'update_taskdef')
+    mocker.patch.object(service, 'find_service_family')
+    mocker.patch.object(service, 'update_service')
+
+    with pytest.raises(DuploError) as exc_info:
+        service.update_image("test-service", container_image=[("typo", "nginx:1.2")])
+
+    assert exc_info.value.code == 404
+    assert "typo" in str(exc_info.value)
+    assert "app" in str(exc_info.value) and "sidecar" in str(exc_info.value)
+    service.update_taskdef.assert_not_called()
+    service.update_service.assert_not_called()
+    assert mock_task_def["ContainerDefinitions"][0]["Image"] == "old-image:1"
+    assert mock_task_def["ContainerDefinitions"][1]["Image"] == "sidecar:1"
+
+
+@pytest.mark.unit
 def test_update_image_no_service(mocker):
     mock_client = mocker.MagicMock()
     service = DuploEcsService(mock_client)


### PR DESCRIPTION
## Describe Changes

Fixes DUPLO-32970. `duploctl ecs update_image --container-image <name> <image>` silently registered a new (identical) task-definition revision and triggered a service rollout when `<name>` didn't match any container on the existing task def.

`update_image` now diffs the supplied container names against the task def before mutating anything and raises `DuploError(..., 404)` naming the unknown container(s) and listing the valid ones — no revision registered, no rollout.

Verified live against `ecs-hc-repro` on a test tenant: bad name raises cleanly with the list of valid containers; valid names still succeed.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-32970

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
