### PR TITLE
fix(jit): mask credentials in GitHub Actions logs via ::add-mask::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `jit` commands (`aws`, `gcp`, `argo_wf`, `k8s`, `token`) leaking credentials in GitHub Actions logs when output was piped to `$GITHUB_OUTPUT`. When `GITHUB_ACTIONS=true`, secret fields are now registered with `::add-mask::` so the runner redacts them in subsequent step logs.
 - Fixed `ssm_param find`/`update`/`delete` returning "Resource not found" for hierarchical parameter names (e.g. `/customer/web/demo`) by double URL-encoding the name in the path segment to match what the portal UI sends (`/` → `%252F`)
 - Fixed `ssm_param apply` crashing with `TypeError: update() got an unexpected keyword argument 'body'` by extending `ssm_param update` to accept `body` and `patches`, aligning it with the V3 base `apply` flow
 - Fixed `ssm_param update` with `patches` (or no value) overwriting a SecureString's real value with the obfuscated `****` placeholder by fetching the current body with `show_sensitive=True`

--- a/src/duplo_resource/jit.py
+++ b/src/duplo_resource/jit.py
@@ -4,6 +4,7 @@ from duplocloud.resource import DuploResource
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
 import os
+import sys
 from pathlib import Path
 import yaml
 import configparser
@@ -15,6 +16,29 @@ INSTALL_HINT = """
 Install duploctl for use with kubectl by following
 https://cli.duplocloud.com/Jit/
 """
+
+
+def _mask_in_ci(values):
+  """Register ::add-mask:: workflow commands so CI runners scrub secrets from logs.
+
+  GitHub Actions logs step inputs verbatim (e.g. the `with:` block of
+  configure-aws-credentials), which exposes JIT credentials piped into
+  `$GITHUB_OUTPUT`. Emitting `::add-mask::<value>` tells the runner to
+  replace that string with `***` everywhere in the rest of the job.
+
+  Writes to stderr because `>> $GITHUB_OUTPUT` redirects stdout only; the
+  runner reads workflow commands from both stdout and stderr.
+
+  Args:
+    values: Iterable of secret strings to register. Empty/None values are
+      skipped — `::add-mask::` with an empty value is a no-op that just
+      wastes a log line.
+  """
+  if os.environ.get("GITHUB_ACTIONS", "").lower() != "true":
+    return
+  for v in values:
+    if v:
+      print(f"::add-mask::{v}", file=sys.stderr, flush=True)
 
 @Resource("jit")
 class DuploJit(DuploResource):
@@ -47,6 +71,7 @@ class DuploJit(DuploResource):
     Returns:
       token: The JWT token.
     """
+    _mask_in_ci([self.client.token])
     return {"token": self.client.token}
 
   @Command()
@@ -88,6 +113,7 @@ class DuploJit(DuploResource):
       if "Expiration" not in sts:
         sts["Expiration"] = self.cache.expiration()
       self.cache.set(k, sts)
+    _mask_in_ci([sts.get("Token")])
     return sts
 
   @Command()
@@ -127,6 +153,7 @@ class DuploJit(DuploResource):
       if "ExpiresAt" not in auth_data:
         auth_data["ExpiresAt"] = self.cache.expiration()
       self.cache.set(k, auth_data)
+    _mask_in_ci([auth_data.get("Token")])
     return auth_data
 
   @Command()
@@ -196,6 +223,12 @@ class DuploJit(DuploResource):
         sts["Expiration"] = self.cache.expiration()
       self.cache.set(k, sts)
     sts["Version"] = 1
+    _mask_in_ci([
+      sts.get("AccessKeyId"),
+      sts.get("SecretAccessKey"),
+      sts.get("SessionToken"),
+      sts.get("ConsoleUrl"),
+    ])
     return sts
 
   @Command()
@@ -309,6 +342,7 @@ class DuploJit(DuploResource):
       ctx = self.k8s_context(planId)
       creds = self.__k8s_exec_credential(ctx)
       self.cache.set(k, creds)
+    _mask_in_ci([creds.get("status", {}).get("token")])
     return creds
 
   @Command()

--- a/src/tests/test_jit.py
+++ b/src/tests/test_jit.py
@@ -3,6 +3,56 @@ import os
 import pytest
 from duplocloud.controller import DuploCtl
 from duplocloud.errors import DuploError
+from duplo_resource import jit as jit_module
+
+
+@pytest.mark.unit
+def test_mask_in_ci_emits_workflow_commands_to_stderr(monkeypatch, capsys):
+  """When GITHUB_ACTIONS=true, each non-empty secret is emitted to stderr."""
+  monkeypatch.setenv("GITHUB_ACTIONS", "true")
+  jit_module._mask_in_ci(["AKIAFAKE", "secret-key", "session-token"])
+  captured = capsys.readouterr()
+  assert captured.out == ""
+  assert "::add-mask::AKIAFAKE" in captured.err
+  assert "::add-mask::secret-key" in captured.err
+  assert "::add-mask::session-token" in captured.err
+
+
+@pytest.mark.unit
+def test_mask_in_ci_skips_empty_values(monkeypatch, capsys):
+  """Empty strings and None are skipped — ::add-mask:: with no value is a no-op."""
+  monkeypatch.setenv("GITHUB_ACTIONS", "true")
+  jit_module._mask_in_ci(["", None, "real-secret"])
+  err = capsys.readouterr().err
+  assert err.count("::add-mask::") == 1
+  assert "::add-mask::real-secret" in err
+
+
+@pytest.mark.unit
+def test_mask_in_ci_noop_outside_github_actions(monkeypatch, capsys):
+  """Without GITHUB_ACTIONS=true, nothing is emitted."""
+  monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+  jit_module._mask_in_ci(["secret"])
+  captured = capsys.readouterr()
+  assert captured.out == ""
+  assert captured.err == ""
+
+
+@pytest.mark.unit
+def test_mask_in_ci_noop_when_github_actions_false(monkeypatch, capsys):
+  """The trigger is the literal string 'true' — 'false' must not mask."""
+  monkeypatch.setenv("GITHUB_ACTIONS", "false")
+  jit_module._mask_in_ci(["secret"])
+  assert capsys.readouterr().err == ""
+
+
+@pytest.mark.unit
+def test_mask_in_ci_accepts_uppercase_true(monkeypatch, capsys):
+  """GitHub's runner sets GITHUB_ACTIONS=true, but be lenient on case."""
+  monkeypatch.setenv("GITHUB_ACTIONS", "TRUE")
+  jit_module._mask_in_ci(["secret"])
+  assert "::add-mask::secret" in capsys.readouterr().err
+
 
 @pytest.mark.integration
 @pytest.mark.jit


### PR DESCRIPTION
## Describe Changes

When `GITHUB_ACTIONS=true`, the `jit` commands now register their secret-bearing fields with the runner's masking system by emitting `::add-mask::<value>` workflow commands to stderr. This stops AWS credentials (and the GCP / Argo / k8s / JWT tokens) from appearing in plain text in subsequent step logs.

- `aws` masks `AccessKeyId`, `SecretAccessKey`, `SessionToken`, `ConsoleUrl`
- `gcp` masks `Token`
- `argo_wf` masks `Token`
- `k8s` masks `status.token`
- `token` masks the JWT

stderr is used so the masks survive `>> $GITHUB_OUTPUT` (which only redirects stdout); the runner reads workflow commands from both streams.

End-to-end verification on a live runner: https://github.com/duplocloud/actions/actions/runs/25868854856 — the `aws-actions/configure-aws-credentials@v6` `with:` block now shows `aws-access-key-id: ***`, `aws-secret-access-key: ***`, `aws-session-token: ***`, while `aws-region: us-west-2` is correctly left un-masked, and `aws sts get-caller-identity` succeeds (creds are intact, only their log representation is redacted).

## Link to Issues

- ClickUp: [DUPLO-42934](https://app.clickup.com/t/8655600/DUPLO-42934)
- DuploCloud Support ticket #41911 (Slack thread, Tiffany Tang)

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog

## Test plan

- [x] 5 new unit tests in `src/tests/test_jit.py` covering: emission to stderr, empty/None skipping, no-op outside `GITHUB_ACTIONS`, no-op when `GITHUB_ACTIONS=false`, case-insensitive `TRUE` trigger
- [x] Full unit suite: 285 pass (1 pre-existing failure in `test_aws_plugin.py::test_client_entry_point_registered`, reproduces on clean origin/main with this branch stashed — not a regression)
- [x] `ruff check src/duplo_resource/jit.py src/tests/test_jit.py` clean
- [x] End-to-end live runner verification against `test24.duplocloud.net` / `duplo-tools` tenant: secrets masked, creds still functional