### PR TITLE
Remove unused pytest-black/pytest-isort dev deps that broke unit-test CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed unit-test CI failing at pytest startup (`PluginValidationError: Plugin 'black' ... Argument(s) {'path'} ... can not be found in the hookspec`) by removing the unused, unmaintained `pytest-black` and `pytest-isort` dev dependencies. They were never invoked (no `--black`/`--isort` in `addopts`) and their old `pytest_collect_file` hook signature is incompatible with current pytest; formatting/lint is handled by `ruff`
+- Removed unused `pytest-black` and `pytest-isort` dev dependencies that broke unit-test CI at pytest startup on current pytest; linting is handled by `ruff`
 - Fixed `ssm_param find`/`update`/`delete` returning "Resource not found" for hierarchical parameter names (e.g. `/customer/web/demo`) by double URL-encoding the name in the path segment to match what the portal UI sends (`/` → `%252F`)
 - Fixed `ssm_param apply` crashing with `TypeError: update() got an unexpected keyword argument 'body'` by extending `ssm_param update` to accept `body` and `patches`, aligning it with the V3 base `apply` flow
 - Fixed `ssm_param update` with `patches` (or no value) overwriting a SecureString's real value with the obfuscated `****` placeholder by fetching the current body with `show_sensitive=True`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed unit-test CI failing at pytest startup (`PluginValidationError: Plugin 'black' ... Argument(s) {'path'} ... can not be found in the hookspec`) by removing the unused, unmaintained `pytest-black` and `pytest-isort` dev dependencies. They were never invoked (no `--black`/`--isort` in `addopts`) and their old `pytest_collect_file` hook signature is incompatible with current pytest; formatting/lint is handled by `ruff`
 - Fixed `ssm_param find`/`update`/`delete` returning "Resource not found" for hierarchical parameter names (e.g. `/customer/web/demo`) by double URL-encoding the name in the path segment to match what the portal UI sends (`/` → `%252F`)
 - Fixed `ssm_param apply` crashing with `TypeError: update() got an unexpected keyword argument 'body'` by extending `ssm_param update` to accept `body` and `patches`, aligning it with the V3 base `apply` flow
 - Fixed `ssm_param update` with `patches` (or no value) overwriting a SecureString's real value with the obfuscated `****` placeholder by fetching the current body with `show_sensitive=True`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ test = [
   "pytest",
   "ruff",
   "pip-audit",
-  "pytest-black",
-  "pytest-isort",
   "pytest-cov",
   "pytest-dependency",
   "pytest-order",


### PR DESCRIPTION
## Describe Changes

Unit-test CI currently fails at **pytest startup, before any test runs**:

```
pluggy._manager.PluginValidationError: Plugin 'black' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(file_path, path, parent)
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
```

Root cause: `pytest-black` (and `pytest-isort`) are unmaintained and still implement the old `pytest_collect_file(file_path, path, parent)` hook; modern pytest removed the `path` argument, so a fresh install resolving current pytest crashes during plugin registration. Both were **unpinned** in the `test` extra, so this is a time-bomb that triggered once a newer pytest released.

These plugins were also **never actually invoked** — there is no `--black`/`--isort` in `addopts`, and they are referenced nowhere except their own dependency lines. Formatting/lint is handled by `ruff` (already a dev dependency and run in the Quality workflow).

This PR removes `pytest-black` and `pytest-isort` from the `test` extra. No behavioral change to what is tested; CI collection no longer crashes.

### Verification

With both plugins uninstalled locally (simulating a fresh CI env) and current pytest 9.1.0:

```
pytest src -m unit  →  284 passed, 113 deselected
```

No `-p no:black` workaround required.

## Link to Issues

N/A — CI infrastructure fix.

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests — N/A; this removes broken, unused test plugins. Verified the full unit suite passes (284 passed).
- [x] Make sure to note changes in Changelog
