### PR TITLE
fix: add V2 fallback for update_image when V3 endpoint unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed `service update_image` failing with `'' not found` (exit 148) on older Duplo backends that lack the V3 containerimage endpoint by falling back to the V2 ReplicationControllerChange endpoint
-
-## [0.4.4] - 2026-06-26
-
 ### Changed
 
 - added ability to pass in kwargs when calling the client as function
@@ -64,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `service update_env` and `update_labels` crashing when `OtherDockerConfig` is empty
 - Fixed `tenant config` crashing with help text when `--deletevar` is not provided
 - Fixed `apply` misrouting the body into the `name` parameter for subclasses whose `create` signature starts with `name` (e.g. `ssm_param`, `secret`, `aws_secret`, `configmap`); the V2 and V3 base `apply` now call `self.create(body=body)` by keyword
+- Fixed `service update_image` failing with `'' not found` (exit 148) on older Duplo backends that lack the V3 containerimage endpoint by falling back to the V2 ReplicationControllerChange endpoint
 
 ## [0.4.3] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `service update_image` failing with `'' not found` (exit 148) on older Duplo backends that lack the V3 containerimage endpoint by falling back to the V2 ReplicationControllerChange endpoint
+
 ## [0.4.4] - 2026-06-26
 
 ### Changed

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -369,11 +369,36 @@ class DuploService(DuploResourceV2):
     old = None
     if self.duplo.wait:
       old = self.find(name)
-    self.client.put(endpoint, payload)
+    try:
+      self.client.put(endpoint, payload)
+    except DuploNotFound:
+      self.duplo.logger.debug("V3 containerimage endpoint not found, falling back to V2")
+      self._update_image_v2(name, image, container_image, init_container_image, old)
+    else:
+      if self.duplo.wait:
+        self.duplo.logger.debug("Wait enabled, beginning wait process")
+        self._wait(old, {"Name": name, "Image": image or ""})
+    return {"message": f"Successfully updated image for service '{name}'."}
+
+  def _update_image_v2(self, name, image, container_image, init_container_image, old):
+    """Fallback to V2 endpoint for older Duplo backends."""
+    if container_image or init_container_image:
+      raise DuploError(
+        "Sidecar and init container image updates require a newer Duplo backend. "
+        "Please upgrade your Duplo portal or use the main image parameter only."
+      )
+    if not image:
+      raise DuploError("No image provided for V2 fallback.")
+    service = old if old else self.find(name)
+    data = {
+      "Name": name,
+      "Image": image,
+      "AllocationTags": service["Template"].get("AllocationTags", "")
+    }
+    self.client.post(self.endpoint("ReplicationControllerChange"), data)
     if self.duplo.wait:
       self.duplo.logger.debug("Wait enabled, beginning wait process")
-      self._wait(old, {"Name": name, "Image": image or ""})
-    return {"message": f"Successfully updated image for service '{name}'."}
+      self._wait(service, data)
 
   @Command()
   def update_env(self,


### PR DESCRIPTION
## Describe Changes

When `service update_image` is used against older Duplo backends that don't have the V3 `containerimage` endpoint, fall back to the V2 `ReplicationControllerChange` endpoint instead of failing with `'' not found` (exit 148).

- Try V3 endpoint first
- On `DuploNotFound`, fall back to V2 for main image updates
- Sidecar/init container updates still require V3 (clear error if attempted on old backend)

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-43456

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog