### PR TITLE
Fix auth cooldown races that open duplicate browser tabs under concurrent auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Auth cooldown (`DUPLO_AUTH_COOLDOWN`) no longer opens duplicate browser tabs when many non-TTY processes authenticate at once: the cooldown file is now published atomically (readers could previously observe it empty and steal the cooldown), the credential cache is written atomically and before the cooldown is released, blocked processes retry instead of failing when the cooldown vanishes mid-check, and only the process that owns the cooldown may clear it.
+
 ### Changed
 
 - added ability to pass in kwargs when calling the client as function

--- a/src/duplo_resource/cache.py
+++ b/src/duplo_resource/cache.py
@@ -58,8 +58,12 @@ class DuploCache():
     if not os.path.exists(self.duplo.cache_dir):
       os.makedirs(self.duplo.cache_dir)
     fn = f"{self.duplo.cache_dir}/{key}.json"
-    with open(fn, "w") as f:
+    # Write to a temp file and rename so concurrent readers never observe
+    # a truncated file (multiple duploctl processes share this cache).
+    tmp = f"{fn}.tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
       json.dump(data, f)
+    os.replace(tmp, fn)
 
   def key_for(self, name: str) -> str:
     """Get the cache key for the given name.

--- a/src/duplo_resource/cache.py
+++ b/src/duplo_resource/cache.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timezone, timedelta
 from duplocloud.commander import Resource, Command
 from duplocloud.errors import DuploExpiredCache
-from duplocloud.authcooldown import clear_all_caches
+from duplocloud.authcooldown import clear_all_caches, atomic_write_json
 
 @Resource("cache", client=None)
 class DuploCache():
@@ -58,12 +58,9 @@ class DuploCache():
     if not os.path.exists(self.duplo.cache_dir):
       os.makedirs(self.duplo.cache_dir)
     fn = f"{self.duplo.cache_dir}/{key}.json"
-    # Write to a temp file and rename so concurrent readers never observe
-    # a truncated file (multiple duploctl processes share this cache).
-    tmp = f"{fn}.tmp.{os.getpid()}"
-    with open(tmp, "w") as f:
-      json.dump(data, f)
-    os.replace(tmp, fn)
+    # Atomic write so concurrent readers never observe a truncated file
+    # (multiple duploctl processes share this cache).
+    atomic_write_json(fn, data)
 
   def key_for(self, name: str) -> str:
     """Get the cache key for the given name.

--- a/src/duplo_resource/cache.py
+++ b/src/duplo_resource/cache.py
@@ -58,8 +58,6 @@ class DuploCache():
     if not os.path.exists(self.duplo.cache_dir):
       os.makedirs(self.duplo.cache_dir)
     fn = f"{self.duplo.cache_dir}/{key}.json"
-    # Atomic write so concurrent readers never observe a truncated file
-    # (multiple duploctl processes share this cache).
     atomic_write_json(fn, data)
 
   def key_for(self, name: str) -> str:

--- a/src/duplocloud/authcooldown.py
+++ b/src/duplocloud/authcooldown.py
@@ -114,6 +114,21 @@ def _auth_cooldown_path(cache_dir: str, host: str, admin: bool) -> str:
   return os.path.join(cache_dir, hostname + suffix)
 
 
+def atomic_write_json(path: str, data: dict) -> None:
+  """Write JSON to a file atomically via a temp file and rename.
+
+  Concurrent readers never observe a truncated or partially written file.
+
+  Args:
+    path: The destination file path.
+    data: The dict to serialize.
+  """
+  tmp_path = f"{path}.tmp.{os.getpid()}"
+  with open(tmp_path, "w") as f:
+    json.dump(data, f)
+  os.replace(tmp_path, path)
+
+
 def _read_info_from_path(path: str) -> dict | None:
   """Read cooldown info from a file path.
 
@@ -274,10 +289,7 @@ def update_cooldown(cache_dir: str, host: str, admin: bool, port: int) -> None:
 
   try:
     cooldown_path = _auth_cooldown_path(cache_dir, host, admin)
-    tmp_path = f"{cooldown_path}.tmp.{os.getpid()}"
-    with open(tmp_path, "w") as f:
-      json.dump(info, f)
-    os.replace(tmp_path, cooldown_path)
+    atomic_write_json(cooldown_path, info)
   except OSError as e:
     logger.warning("auth cooldown: failed to update cooldown for relay: %s", e)
 

--- a/src/duplocloud/authcooldown.py
+++ b/src/duplocloud/authcooldown.py
@@ -185,7 +185,7 @@ def _try_set_cooldown(cooldown_path: str, port: int, admin: bool, cooldown_durat
   }
 
   try:
-    fd = os.open(cooldown_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    _publish_cooldown_file(cooldown_path, info)
   except FileExistsError:
     existing = _read_info_from_path(cooldown_path)
     if retry_on_stale and (existing is None or _is_stale(existing, cooldown_duration)):
@@ -208,17 +208,36 @@ def _try_set_cooldown(cooldown_path: str, port: int, admin: bool, cooldown_durat
   except OSError as e:
     return False, None, f"failed to create cooldown file: {e}"
 
+  return True, None, None
+
+
+def _publish_cooldown_file(cooldown_path: str, info: dict) -> None:
+  """Atomically create the cooldown file with its full content.
+
+  The file must never be observable empty: a concurrent reader that finds
+  unparseable content treats the cooldown as stale and steals it, opening a
+  duplicate browser tab. Writing to a temp file and hard-linking it into
+  place makes creation exclusive AND content-complete in one step.
+
+  Args:
+    cooldown_path: The final cooldown file path.
+    info: The cooldown info dict to write.
+
+  Raises:
+    FileExistsError: If a cooldown file already exists.
+    OSError: On other filesystem errors.
+  """
+  tmp_path = f"{cooldown_path}.tmp.{os.getpid()}"
   try:
+    fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
     with os.fdopen(fd, "w") as f:
       json.dump(info, f)
-  except OSError:
+    os.link(tmp_path, cooldown_path)
+  finally:
     try:
-      os.remove(cooldown_path)
+      os.remove(tmp_path)
     except OSError:
       pass
-    return False, None, "failed to write cooldown file"
-
-  return True, None, None
 
 
 def _is_stale(info: dict, cooldown_duration: int) -> bool:
@@ -255,8 +274,10 @@ def update_cooldown(cache_dir: str, host: str, admin: bool, port: int) -> None:
 
   try:
     cooldown_path = _auth_cooldown_path(cache_dir, host, admin)
-    with open(cooldown_path, "w") as f:
+    tmp_path = f"{cooldown_path}.tmp.{os.getpid()}"
+    with open(tmp_path, "w") as f:
       json.dump(info, f)
+    os.replace(tmp_path, cooldown_path)
   except OSError as e:
     logger.warning("auth cooldown: failed to update cooldown for relay: %s", e)
 
@@ -398,6 +419,12 @@ def check_cooldown_before_listen(cache_dir: str, host: str, admin: bool, default
     result = _wait_for_cooldown_holder(cache_dir, host, admin, default_port, info, cooldown_duration, get_cached_token)
     return default_port, True, cooldown_duration, result
 
+  # The holder is gone — it may have just finished successfully, in which
+  # case the cached token is fresher than a relay attempt.
+  result = _cached_token_result(get_cached_token)
+  if result:
+    return default_port, True, cooldown_duration, result
+
   logger.info("auth cooldown: previous process (PID %d) is dead, attempting relay on port %d",
         pid, info.get("port", 0))
   return info.get("port", default_port), False, remaining, None
@@ -453,11 +480,13 @@ def acquire_or_update_cooldown(cache_dir: str, host: str, admin: bool, default_p
       info = read_cooldown_info(cache_dir, host, admin)
       if info:
         return _wait_for_cooldown_holder(cache_dir, host, admin, default_port, info, cooldown_duration, get_cached_token)
-      expiry_str = expiry.isoformat() if expiry else "unknown"
-      return CooldownResult(error=(
-        f"authentication for {get_host_cache_key(host)} was recently attempted (expires {expiry_str})\n"
-        f"To force a new attempt: duploctl cache clear  (or unset {AUTH_COOLDOWN_ENV_VAR} to disable cooldown)"
-      ))
+      # The cooldown vanished between the acquire attempt and the re-read:
+      # the holder finished (token may be cached) or the file was cleared.
+      result = _cached_token_result(get_cached_token)
+      if result:
+        return result
+      time.sleep(0.2)
+      return CooldownResult(retry=True)
   else:
     update_cooldown(cache_dir, host, admin, local_port)
   return None

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -102,6 +102,7 @@ class DuploAPI():
             get_cached_token=self._try_cached_token))
       raise
 
+    owns_cooldown = False
     with server:
       try:
         if use_cooldown:
@@ -111,6 +112,7 @@ class DuploAPI():
               get_cached_token=self._try_cached_token)
           if cd_result is not None:
             return self._handle_cooldown_result(cd_result)
+          owns_cooldown = True
 
         if open_browser:
           page = f"{path}?localAppName=duploctl&localPort={server.server_port}&isAdmin={isadmin}&redirect=true"
@@ -121,12 +123,16 @@ class DuploAPI():
 
         token = server.serve_token()
 
-        if use_cooldown:
+        if owns_cooldown:
+          # Cache the token before releasing the cooldown so a process that
+          # sees no cooldown file always finds the cached credentials.
+          if not self.duplo.nocache:
+            self.cache.set(self.cache.key_for("duplo-creds"), self._token_cache(token))
           clear_auth_cooldown(self.duplo.cache_dir, self.duplo.host, self.duplo.isadmin)
 
         return token
       except DuploError:
-        if use_cooldown:
+        if owns_cooldown:
           clear_auth_cooldown(self.duplo.cache_dir, self.duplo.host, self.duplo.isadmin)
         raise
       except KeyboardInterrupt:

--- a/src/duplocloud/client.py
+++ b/src/duplocloud/client.py
@@ -125,9 +125,13 @@ class DuploAPI():
 
         if owns_cooldown:
           # Cache the token before releasing the cooldown so a process that
-          # sees no cooldown file always finds the cached credentials.
+          # sees no cooldown file always finds the cached credentials. A
+          # failed cache write must not fail the auth or orphan the cooldown.
           if not self.duplo.nocache:
-            self.cache.set(self.cache.key_for("duplo-creds"), self._token_cache(token))
+            try:
+              self.cache.set(self.cache.key_for("duplo-creds"), self._token_cache(token))
+            except OSError as e:
+              self.duplo.logger.warning("auth cooldown: failed to cache token: %s", e)
           clear_auth_cooldown(self.duplo.cache_dir, self.duplo.host, self.duplo.isadmin)
 
         return token

--- a/src/tests/test_authcooldown.py
+++ b/src/tests/test_authcooldown.py
@@ -647,3 +647,90 @@ class TestAcquireOrUpdateCooldownEdgeCases:
 def test_is_tty_returns_bool():
   result = is_tty()
   assert isinstance(result, bool)
+
+
+# --- Regression tests for concurrent-burst races (DUPLO-41877) ---
+
+@pytest.mark.unit
+class TestCooldownFileAtomicity:
+  def test_publish_writes_complete_content(self, tmp_path):
+    """The cooldown file must contain valid JSON the instant it exists."""
+    host, cache_dir = setup_test_host(tmp_path)
+    must_set_cooldown(cache_dir, host, 8080, False, 3600)
+
+    cooldown_path = _auth_cooldown_path(cache_dir, host, False)
+    with open(cooldown_path) as f:
+      info = json.load(f)
+    assert info["pid"] == os.getpid()
+    assert info["port"] == 8080
+
+  def test_publish_leaves_no_temp_file(self, tmp_path):
+    host, cache_dir = setup_test_host(tmp_path)
+    must_set_cooldown(cache_dir, host, 8080, False, 3600)
+    leftovers = [e for e in os.listdir(cache_dir) if ".tmp." in e]
+    assert leftovers == []
+
+  def test_publish_raises_when_file_exists(self, tmp_path):
+    from duplocloud.authcooldown import _publish_cooldown_file
+    host, cache_dir = setup_test_host(tmp_path)
+    cooldown_path = _auth_cooldown_path(cache_dir, host, False)
+    _publish_cooldown_file(cooldown_path, {"pid": 1})
+    with pytest.raises(FileExistsError):
+      _publish_cooldown_file(cooldown_path, {"pid": 2})
+
+  def test_empty_file_is_treated_as_corrupt_and_replaced(self, tmp_path):
+    """With atomic publish an empty cooldown file can only be a corrupt
+    leftover, so a new process may safely replace it."""
+    host, cache_dir = setup_test_host(tmp_path)
+    cooldown_path = _auth_cooldown_path(cache_dir, host, False)
+    with open(cooldown_path, "w"):
+      pass
+
+    must_set_cooldown(cache_dir, host, 8080, False, 3600)
+    info = read_cooldown_info(cache_dir, host, False)
+    assert info["pid"] == os.getpid()
+
+  def test_update_cooldown_leaves_no_temp_file(self, tmp_path):
+    host, cache_dir = setup_test_host(tmp_path)
+    write_fake_cooldown(cache_dir, host, False, 9999, 8080,
+              datetime.now(timezone.utc))
+    update_cooldown(cache_dir, host, False, 5555)
+    leftovers = [e for e in os.listdir(cache_dir) if ".tmp." in e]
+    assert leftovers == []
+
+
+@pytest.mark.unit
+class TestVanishedCooldownRecovery:
+  def test_acquire_retries_when_cooldown_vanishes(self, tmp_path, monkeypatch):
+    """If the cooldown disappears between the failed acquire and the re-read
+    (holder just finished), the caller should retry, not hard-fail."""
+    import duplocloud.authcooldown as ac
+    host, cache_dir = setup_test_host(tmp_path)
+    monkeypatch.setattr(ac, "try_set_auth_cooldown",
+              lambda *a, **kw: (False, None, None))
+
+    result = acquire_or_update_cooldown(cache_dir, host, False, 0, 9090, True, 3600)
+    assert result == CooldownResult(retry=True)
+
+  def test_acquire_uses_cached_token_when_cooldown_vanishes(self, tmp_path, monkeypatch):
+    import duplocloud.authcooldown as ac
+    host, cache_dir = setup_test_host(tmp_path)
+    monkeypatch.setattr(ac, "try_set_auth_cooldown",
+              lambda *a, **kw: (False, None, None))
+
+    result = acquire_or_update_cooldown(
+      cache_dir, host, False, 0, 9090, True, 3600,
+      get_cached_token=lambda: "vanished-cached")
+    assert result == CooldownResult(token="vanished-cached")
+
+  def test_dead_holder_with_cached_token_skips_relay(self, tmp_path):
+    """A dead holder that already cached a token means auth completed —
+    return the token instead of relaying on the old port."""
+    host, cache_dir = setup_test_host(tmp_path)
+    write_fake_cooldown(cache_dir, host, False, 2147483647, 54321,
+              datetime.now(timezone.utc) - timedelta(seconds=600))
+
+    port, browser, timeout, result = check_cooldown_before_listen(
+      cache_dir, host, False, 0, 3600,
+      get_cached_token=lambda: "holder-finished")
+    assert result == CooldownResult(token="holder-finished")

--- a/src/tests/test_authcooldown.py
+++ b/src/tests/test_authcooldown.py
@@ -734,3 +734,55 @@ class TestVanishedCooldownRecovery:
       cache_dir, host, False, 0, 3600,
       get_cached_token=lambda: "holder-finished")
     assert result == CooldownResult(token="holder-finished")
+
+
+@pytest.mark.unit
+class TestRequestTokenCacheFailure:
+  def test_cache_write_failure_still_clears_cooldown_and_returns_token(self, tmp_path, monkeypatch):
+    """A failed credential-cache write must not fail the auth or leave the
+    cooldown file orphaned behind a dead PID."""
+    from unittest.mock import MagicMock
+    import duplocloud.client as cl
+    from duplocloud.client import DuploAPI
+
+    host, cache_dir = setup_test_host(tmp_path)
+
+    duplo = MagicMock()
+    duplo.host = host
+    duplo.cache_dir = cache_dir
+    duplo.isadmin = False
+    duplo.nocache = False
+    duplo.auth_cooldown = "true"
+    duplo.browser = None
+
+    api = DuploAPI.__new__(DuploAPI)
+    api.duplo = duplo
+    api.cache = MagicMock()
+    api.cache.set.side_effect = OSError("disk full")
+    api.cache.get.side_effect = OSError("disk full")
+
+    class FakeServer:
+      server_port = 12345
+
+      def __init__(self, *args, **kwargs):
+        pass
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, *args):
+        return False
+
+      def open_callback(self, *args, **kwargs):
+        pass
+
+      def serve_token(self):
+        return "tok123"
+
+    monkeypatch.setattr(cl, "TokenServer", FakeServer)
+    monkeypatch.setattr(cl, "is_tty", lambda: False)
+
+    token = api.request_token()
+    assert token == "tok123"
+    # Cooldown must be released even though caching the token failed.
+    assert read_cooldown_info(cache_dir, host, False) is None

--- a/src/tests/test_cache_resource.py
+++ b/src/tests/test_cache_resource.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 @pytest.mark.unit
@@ -70,3 +70,31 @@ class TestCacheResource:
 
     assert result == {"message": "Cleared 1 cached file(s)"}
     assert "subdir" in os.listdir(cache_dir)
+
+  def test_set_get_roundtrip(self, tmp_path):
+    """Test set writes a readable JSON file and get returns it."""
+    cache_dir = str(tmp_path / "cache")
+
+    mock_duplo = MagicMock()
+    mock_duplo.cache_dir = cache_dir
+
+    from duplo_resource.cache import DuploCache
+    resource = DuploCache(mock_duplo)
+    resource.set("mykey", {"DuploToken": "abc"})
+
+    assert resource.get("mykey") == {"DuploToken": "abc"}
+
+  def test_set_leaves_no_temp_file(self, tmp_path):
+    """Test the atomic write leaves no .tmp leftovers (DUPLO-41877)."""
+    cache_dir = str(tmp_path / "cache")
+
+    mock_duplo = MagicMock()
+    mock_duplo.cache_dir = cache_dir
+
+    from duplo_resource.cache import DuploCache
+    resource = DuploCache(mock_duplo)
+    resource.set("mykey", {"DuploToken": "abc"})
+
+    leftovers = [e for e in os.listdir(cache_dir) if ".tmp." in e]
+    assert leftovers == []
+    assert "mykey.json" in os.listdir(cache_dir)


### PR DESCRIPTION
## Describe Changes

QA found that with `DUPLO_AUTH_COOLDOWN=true`, concurrent non-TTY `duploctl jit token --interactive` calls still opened multiple browser tabs. Reproduced locally with a 3–5 process burst (stubbed browser): 2 tabs opened on most runs. Four related races, all fixed:

- **Cooldown file observable empty**: `_try_set_cooldown` created the file with `O_EXCL` and wrote the JSON afterwards. A concurrent process reading in that window got unparseable content, treated the cooldown as stale, stole it, and opened a second tab. The file is now written to a temp path and hard-linked into place, so creation is exclusive and content-complete in one atomic step.
- **Credential cache truncated in place**: `cache.set` used `open(fn, "w")`, so a process reading mid-rewrite saw a corrupt cache, missed the token, and opened a fresh tab. Now writes temp + `os.replace` (same for the relay `update_cooldown` rewrite).
- **Hard error instead of retry**: when the cooldown file vanished between a failed acquire and the re-read (holder just finished), the blocked process errored out — and its error handler cleared the *winner's* active cooldown file. Blocked processes now check the cache and retry, and only the process that owns the cooldown may clear it.
- **Cooldown released before token cached**: the winner now writes the token to the credential cache before clearing the cooldown, so a process that sees no cooldown always finds the cached credentials.

Verification: before the fix, 5-process bursts opened 2 tabs in 5/30 runs (3-process bursts failed nearly every run). After: 0 failures in 30×5-process runs; a 10-process burst opened exactly 1 tab and all 10 processes got tokens; control run with cooldown unset still opens one tab per process as expected.

## Link to Issues

[DUPLO-41877](https://app.clickup.com/t/8655600/DUPLO-41877)

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog