### PR TITLE
fix: get integration tests green on qa-aws; run them by default in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
       run_e2e:
         description: Run end to end tests
         required: false
-        default: false
+        default: true
         type: boolean
       e2e_environment:
         description: GHA environment for integration tests (e.g. qa-aws)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: qa-aws
         type: environment
+      e2e_region:
+        description: AWS region override for integration test infrastructure
+        required: false
+        default: ""
+        type: string
 
 jobs:
 
@@ -48,6 +53,7 @@ jobs:
       environment: ${{ inputs.e2e_environment }}
       enabled: ${{ inputs.run_e2e && 'true' || 'false' }}
       suite: aws
+      region: ${{ inputs.e2e_region }}
 
   integration_k8s:
     name: Integration Tests
@@ -57,6 +63,7 @@ jobs:
       environment: ${{ inputs.e2e_environment }}
       enabled: ${{ inputs.run_e2e && 'true' || 'false' }}
       suite: k8s
+      region: ${{ inputs.e2e_region }}
 
   integration_ecs:
     name: Integration Tests
@@ -66,6 +73,7 @@ jobs:
       environment: ${{ inputs.e2e_environment }}
       enabled: ${{ inputs.run_e2e && 'true' || 'false' }}
       suite: ecs
+      region: ${{ inputs.e2e_region }}
 
   version:
     name: Version

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -23,6 +23,10 @@ on:
         required: false
         description: Pre-existing tenant name. Empty mirrors infra name.
         type: string
+      region:
+        required: false
+        description: AWS region override for infrastructure creation. Empty uses the test data default.
+        type: string
       python_version:
         required: false
         description: Python version
@@ -50,6 +54,9 @@ on:
         required: false
         type: string
       tenant:
+        required: false
+        type: string
+      region:
         required: false
         type: string
       python_version:
@@ -133,11 +140,13 @@ jobs:
         INFRA: ${{ inputs.infra }}
         TENANT: ${{ inputs.tenant }}
         INFRA_TYPE: ${{ steps.suite.outputs.infra_type }}
+        REGION: ${{ inputs.region }}
       run: |
         ARGS=(src -m "integration and lifecycle" --no-cov --junit-xml=lifecycle-results.xml -v -s --names-file=.names --no-teardown)
         if [ -n "$INFRA" ]; then ARGS+=(--infra "$INFRA"); fi
         if [ -n "$TENANT" ]; then ARGS+=(--tenant "$TENANT"); fi
         if [ -n "$INFRA_TYPE" ]; then ARGS+=(--infra-type "$INFRA_TYPE"); fi
+        if [ -n "$REGION" ]; then ARGS+=(--region "$REGION"); fi
         pytest "${ARGS[@]}"
 
     - name: Export resolved names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Integration tests generate tenant names as `dctl{n}` instead of `duploctl{n}` to avoid the portal's shared-prefix conflict with the existing `duploctl` tenant on QA portals
 - Integration test workflow accepts a `region` input (and `publish.yml` an `e2e_region` input) to create test infrastructure in an alternate AWS region, e.g. to avoid per-region VPC quota exhaustion
+- Publish workflow runs integration tests by default (`run_e2e` now defaults to true; uncheck to skip for e.g. hotfixes)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Integration tests generate tenant names as `dctl{n}` instead of `duploctl{n}` to avoid the portal's shared-prefix conflict with the existing `duploctl` tenant on QA portals
+- Integration test workflow accepts a `region` input (and `publish.yml` an `e2e_region` input) to create test infrastructure in an alternate AWS region, e.g. to avoid per-region VPC quota exhaustion
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Integration tests generate tenant names as `dctl{n}` instead of `duploctl{n}` to avoid the portal's shared-prefix conflict with the existing `duploctl` tenant on QA portals
+
 - added ability to pass in kwargs when calling the client as function
 - **Authentication cooldown** via `DUPLO_AUTH_COOLDOWN` — prevents duplicate browser login prompts when multiple processes request tokens concurrently. Thanks to [@scholzie](https://github.com/scholzie) for the original contribution in [duplocloud/duplo-jit#52](https://github.com/duplocloud/duplo-jit/pull/52).
 - **Cache resource** with `duploctl cache clear` command to remove cached credentials and cooldown files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Integration tests generate tenant names as `dctl{n}` instead of `duploctl{n}` to avoid the portal's shared-prefix conflict with the existing `duploctl` tenant on QA portals
 
+### Fixed
+
+- `rds engine_versions` works against newer portals that removed the combined `engineVersions` endpoint — uses the per-engine `rds/catalog` endpoints and falls back to the old endpoint on older portals
+
 - added ability to pass in kwargs when calling the client as function
 - **Authentication cooldown** via `DUPLO_AUTH_COOLDOWN` — prevents duplicate browser login prompts when multiple processes request tokens concurrently. Thanks to [@scholzie](https://github.com/scholzie) for the original contribution in [duplocloud/duplo-jit#52](https://github.com/duplocloud/duplo-jit/pull/52).
 - **Cache resource** with `duploctl cache clear` command to remove cached credentials and cooldown files

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -1,5 +1,5 @@
 from duplocloud.controller import DuploCtl
-from duplocloud.errors import DuploError, DuploStillWaiting
+from duplocloud.errors import DuploError, DuploNotFound, DuploStillWaiting
 from duplocloud.resource import DuploResourceV3
 from duplocloud.commander import Command, Resource
 import duplocloud.args as args
@@ -478,10 +478,24 @@ class DuploRDS(DuploResourceV3):
 
   @Command()
   def engine_versions(self) -> dict:
-    """List supported RDS engine versions and instance types."""
-    path = f"v3/subscriptions/{self.tenant_id}/aws/rds/engineVersions"
-    response = self.client.post(path, {})
-    return response.json()
+    """List supported RDS engine versions per engine.
+
+    Newer portals removed the combined engineVersions endpoint in favor
+    of per-engine catalog endpoints; older portals only have the
+    combined one. Try the catalog first and fall back on 404.
+    """
+    catalog = f"v3/subscriptions/{self.tenant_id}/aws/rds/catalog"
+    try:
+      engines = self.client.get(f"{catalog}/engines").json()
+      data = {
+        engine: self.client.get(f"{catalog}/engines/{engine}/versions").json()
+        for engine in engines
+      }
+      return {"EngineVersions": {"Data": data}}
+    except DuploNotFound:
+      path = f"v3/subscriptions/{self.tenant_id}/aws/rds/engineVersions"
+      response = self.client.post(path, {})
+      return response.json()
 
   def name_from_body(self, body):
     other_name = body.get("DBInstanceIdentifier", None)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -128,7 +128,7 @@ def infra_name(pytestconfig) -> str:
     2. If --tenant / DUPLO_TENANT is given but no --infra:
          a. Tenant already exists  → use its PlanID as the infra name.
          b. Tenant does not exist  → use the tenant name as the infra name.
-    3. Neither given  → generate a unique name (duploctl{1000-9999}).
+    3. Neither given  → generate a unique name (dctl{1000-9999}).
   """
   if _is_unit_run(pytestconfig):
     return None
@@ -151,8 +151,11 @@ def infra_name(pytestconfig) -> str:
     # Tenant doesn't exist: infra name mirrors the tenant name.
     return tenant_hint
 
+  # Duplo rejects tenant names that share a prefix with an existing tenant,
+  # so avoid "duploctl{n}" — a real tenant named "duploctl" exists on the QA
+  # portals and 409s every generated name.
   inc = random.randint(1000, 9999)
-  return f"duploctl{inc}"
+  return f"dctl{inc}"
 
 @pytest.fixture(scope='session', autouse=True)
 def tenant_name(pytestconfig, infra_name) -> str:


### PR DESCRIPTION
## Describe Changes

Fixes and workflow changes from re-enabling the integration test runs on `qa-aws` (all three suites now pass — see runs below):

1. **Test tenant name prefix conflict** — a real, delete-protected tenant named `duploctl` now exists on the QA portal, and Duplo rejects any new tenant whose name shares a prefix with an existing tenant, so every generated `duploctl{n}` test name 409'd. Generated names are now `dctl{n}`.

2. **`rds engine_versions` broken on newer portals** — the backend removed the combined `v3/subscriptions/{id}/aws/rds/engineVersions` endpoint. The command now queries the new per-engine `rds/catalog` endpoints (preserving the previous `{EngineVersions: {Data: {engine: [...]}}}` output shape) and falls back to the old endpoint on portals that predate the catalog routes.

3. **`region` input for integration tests** (`e2e_region` in publish.yml) — creates test infrastructure in an alternate AWS region. Needed because qa-aws's default region sits near the AWS per-region VPC quota (Duplo reports it as "maximum number of Infrastructures has been reached").

4. **`run_e2e` now defaults to true in publish.yml** — releases run the full integration suite unless explicitly opted out (e.g. hotfixes).

Validated from this branch against qa-aws:
- aws suite ✅ https://github.com/duplocloud/duploctl/actions/runs/29104540277
- ecs suite ✅ https://github.com/duplocloud/duploctl/actions/runs/29101612785
- k8s suite ✅ (us-west-2 via the new region input) https://github.com/duplocloud/duploctl/actions/runs/29106153390

All test infra teardowns verified clean.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-43676

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [ ] Have you added any tests
- [x] Make sure to note changes in Changelog
