### PR TITLE
fix: duploctl cache clear never executed — DuploCache missing DuploResource dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `duploctl cache clear` actually clears the cache now — `DuploCache` did not extend `DuploResource`, so the CLI could not dispatch the `clear` command and printed the resource docstring instead of removing cached credentials and cooldown files
 - Auth cooldown (`DUPLO_AUTH_COOLDOWN`) no longer opens duplicate browser tabs when many non-TTY processes authenticate at once: the cooldown file is now published atomically (readers could previously observe it empty and steal the cooldown), the credential cache is written atomically and before the cooldown is released, blocked processes retry instead of failing when the cooldown vanishes mid-check, and only the process that owns the cooldown may clear it.
 
 ### Changed

--- a/src/duplo_resource/cache.py
+++ b/src/duplo_resource/cache.py
@@ -3,17 +3,18 @@ import os
 from datetime import datetime, timezone, timedelta
 from duplocloud.commander import Resource, Command
 from duplocloud.errors import DuploExpiredCache
+from duplocloud.resource import DuploResource
 from duplocloud.authcooldown import clear_all_caches, atomic_write_json
 
 @Resource("cache", client=None)
-class DuploCache():
+class DuploCache(DuploResource):
   """Cache Resource
 
   Filesystem cache operations for storing and retrieving JSON data.
   Also provides CLI commands for managing the cache.
   """
   def __init__(self, duplo):
-    self.duplo = duplo
+    super().__init__(duplo)
 
   @Command()
   def clear(self) -> dict:

--- a/src/tests/test_cache_resource.py
+++ b/src/tests/test_cache_resource.py
@@ -71,6 +71,29 @@ class TestCacheResource:
     assert result == {"message": "Cleared 1 cached file(s)"}
     assert "subdir" in os.listdir(cache_dir)
 
+  def test_clear_via_cli_dispatch(self, tmp_path):
+    """Test clear runs through resource(cmd) dispatch like the CLI does.
+
+    Regression test for DUPLO-41877: DuploCache did not extend
+    DuploResource, so `duploctl cache clear` raised a TypeError and
+    printed the class docstring instead of clearing anything.
+    """
+    cache_dir = str(tmp_path / "cache")
+    os.makedirs(cache_dir)
+    with open(os.path.join(cache_dir, "host-duplo-creds.json"), "w") as f:
+      f.write("{}")
+
+    mock_duplo = MagicMock()
+    mock_duplo.cache_dir = cache_dir
+    mock_duplo.validate = False
+
+    from duplo_resource.cache import DuploCache
+    resource = DuploCache(mock_duplo)
+    result = resource("clear")
+
+    assert result == {"message": "Cleared 1 cached file(s)"}
+    assert os.listdir(cache_dir) == []
+
   def test_set_get_roundtrip(self, tmp_path):
     """Test set writes a readable JSON file and get returns it."""
     cache_dir = str(tmp_path / "cache")


### PR DESCRIPTION
## Describe Changes

`duploctl cache clear` never actually ran: `DuploCache` did not extend `DuploResource`, so it had no `__call__(cmd)` dispatch. The CLI's `r("clear")` raised a `TypeError`, which the controller converted into a `DuploError` that printed the class docstring and exited non-zero — leaving cached credentials and cooldown files untouched. Reported by QA on DUPLO-41877: after `cache clear`, an interactive login still returned a stale cached token without opening the browser.

Fix: `DuploCache` now extends `DuploResource` (registration stays `client=None`, and `DuploResource` contributes no inherited commands). Added a regression test that exercises the `resource("clear")` dispatch path the CLI uses, plus a changelog entry.

Verified end-to-end: `duploctl cache clear` on a populated cache dir returns `{"message": "Cleared 2 cached file(s)"}`, exit 0, directory emptied.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-41877

## PR Review Checklist

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog