### PR TITLE
DUPLO-43791: park ASGs and k8s/native services on tenant stop/start (ECS out of scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `tenant stop`/`tenant start` now scale Auto Scaling Groups to zero and back. Previously the sweep only stopped native hosts and RDS, so ASG-managed hosts were relaunched by the group and the tenant never actually parked. Each ASG's prior `MinSize`/`MaxSize`/`DesiredCapacity` (and `CanScaleFromZero`) is snapshotted into the ASG's custom data before it is scaled to zero, and restored — then cleared — on start. Exclude specific groups with `--exclude asg/<name>`.
-- ASG-managed hosts are now excluded from the native-host sweep in `tenant stop`/`tenant start` (detected via the `aws:autoscaling:groupName` tag, falling back to the ASG naming convention), so the group scales them down instead of the host sweep stopping instances the ASG would immediately relaunch.
-- `rds stop`/`tenant stop` no longer report an already-stopped Aurora/cluster as a failure. The benign-state check only matched the instance-level "is not in available state" wording; it now also matches the cluster-level "is in stopped state but expected …", so re-running stop on an already-stopped cluster is skipped (as it already was for instances) instead of exiting non-zero.
-- `tenant stop`/`tenant start` now also stop/start ReplicationController services (k8s and native Docker; ECS is not included), not just infrastructure. Services use the platform's native `ReplicationController` suspend/resume, so the configured replica count is preserved by the backend and no snapshot is needed. The sweep is ordered so services drain before their compute is pulled on stop, and compute is restored before services resume on start. Exclude specific services with `--exclude service/<name>`.
+- `tenant stop`/`start` now scale ASGs to zero and back (prior sizing snapshotted in the ASG's custom data), and skip ASG-managed hosts in the host sweep so the group handles them. Exclude with `--exclude asg/<name>`.
+- `tenant stop`/`start` now also stop/start ReplicationController services (k8s and native Docker, not ECS); the platform preserves replica counts. Exclude with `--exclude service/<name>`.
+- `tenant stop` treats an already-stopped Aurora cluster as benign instead of a failure.
 
 ## [0.4.5] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `tenant stop`/`tenant start` now scale Auto Scaling Groups to zero and back. Previously the sweep only stopped native hosts and RDS, so ASG-managed hosts were relaunched by the group and the tenant never actually parked. Each ASG's prior `MinSize`/`MaxSize`/`DesiredCapacity` (and `CanScaleFromZero`) is snapshotted into the ASG's custom data before it is scaled to zero, and restored — then cleared — on start. Exclude specific groups with `--exclude asg/<name>`.
+- ASG-managed hosts are now excluded from the native-host sweep in `tenant stop`/`tenant start` (detected via the `aws:autoscaling:groupName` tag, falling back to the ASG naming convention), so the group scales them down instead of the host sweep stopping instances the ASG would immediately relaunch.
+- `rds stop`/`tenant stop` no longer report an already-stopped Aurora/cluster as a failure. The benign-state check only matched the instance-level "is not in available state" wording; it now also matches the cluster-level "is in stopped state but expected …", so re-running stop on an already-stopped cluster is skipped (as it already was for instances) instead of exiting non-zero.
+- `tenant stop`/`tenant start` now also stop/start ReplicationController services (k8s and native Docker; ECS is not included), not just infrastructure. Services use the platform's native `ReplicationController` suspend/resume, so the configured replica count is preserved by the backend and no snapshot is needed. The sweep is ordered so services drain before their compute is pulled on stop, and compute is restored before services resume on start. Exclude specific services with `--exclude service/<name>`.
+
 ## [0.4.5] - 2026-07-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,9 @@ test = [
   # hook signature that pytest 9.1 removed, which crashes plugin registration.
   # Pin below 9.1 until pytest-black/pytest-isort are dropped in favor of ruff.
   "pytest<9.1",
-  "ruff",
+  # ruff 0.16 enabled new rules (I001/PLR0402/RUF015/...) that flag many
+  # pre-existing files. Pin below 0.16 until the tree is cleaned up.
+  "ruff<0.16",
   "pip-audit",
   "pytest-cov",
   "pytest-dependency",

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -354,6 +354,9 @@ class DuploAsg(DuploResourceV2):
     zeros. Genuine failures are collected and returned rather than
     aborting the sweep.
 
+    info:
+      This is not a cli command. It's primarily used internally but could be useful in a custom script.
+
     Args:
       exclude: ASG FriendlyNames to leave running.
 
@@ -404,6 +407,9 @@ class DuploAsg(DuploResourceV2):
 
     Mirror of ``stop_resources``. ASGs without a snapshot are skipped
     (nothing to restore). Genuine failures are collected and returned.
+
+    info:
+      This is not a cli command. It's primarily used internally but could be useful in a custom script.
 
     Args:
       exclude: ASG FriendlyNames to leave stopped.

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -1,3 +1,5 @@
+import json
+
 from duplocloud.controller import DuploCtl
 from duplocloud.resource import DuploResourceV2
 from duplocloud.errors import DuploError, DuploNotFound
@@ -265,3 +267,168 @@ class DuploAsg(DuploResourceV2):
     }
     self.client.post(f"subscriptions/{tenant_id}/UpdateCustomData", payload)
     return {"message": f"Successfully updated allocation tag for asg '{name}'"}
+
+  # Key under which tenant stop/start snapshots an ASG's prior sizing so
+  # start can restore it. Stored in the ASG's custom data (no ':' so it is
+  # a valid AWS tag key). Not "AllocationTags", so it never affects
+  # service placement.
+  _SLEEP_KEY = "DuploctlSleepState"
+
+  def _set_custom_data(self, asg_name, key, value, delete=False):
+    """Set or clear one ASG custom-data key via UpdateCustomData.
+
+    Writes land in the profile's ``CustomDataTags`` and are read back on
+    the next ``list``/``find`` (the same channel as allocation tags).
+
+    Args:
+      asg_name: The prefixed FriendlyName of the ASG.
+      key: The custom-data key.
+      value: The value to store (ignored when deleting).
+      delete: When True, remove the key instead of setting it.
+    """
+    tenant_id = self.tenant["TenantId"]
+    payload = {
+      "ComponentId": asg_name,
+      "ComponentType": 3,  # ASG (see CustomComponentType enum)
+      "Key": key,
+      "Value": "" if delete else value,
+      "State": "delete" if delete else "create",
+    }
+    self.client.post(f"subscriptions/{tenant_id}/UpdateCustomData", payload)
+
+  def _get_custom_data(self, asg, key):
+    """Read one custom-data value off an ASG profile body.
+
+    Args:
+      asg: An ASG profile body as returned by ``list``/``find``.
+      key: The custom-data key to look up.
+
+    Returns:
+      The stored value, or None if the key is not present.
+    """
+    for kv in (asg.get("CustomDataTags") or []):
+      if kv.get("Key") == key:
+        return kv.get("Value")
+    return None
+
+  # Computed fields the backend returns but does not accept back on
+  # update (Terraform's expandAsgProfile omits them too).
+  _READONLY_ASG_FIELDS = ("Status", "AutoScalingGroupARN", "Created")
+
+  def _apply_capacity(self, asg, min_size, max_size, desired,
+                      can_scale_from_zero=None):
+    """Update an ASG's capacity by re-sending its full profile.
+
+    ``UpdateTenantAsgProfile`` validates and applies the *entire*
+    submitted profile — omitted fields fall back to defaults. A sparse
+    body therefore silently no-ops the capacity change and mis-validates
+    flags such as ``CanScaleFromZero`` (which the backend rejects unless
+    ``IsClusterAutoscaled`` is present and true). So start from the
+    current profile and override only the capacity fields, as the
+    Terraform provider does.
+
+    Args:
+      asg: The full ASG profile body from ``list``/``find``.
+      min_size: New minimum size.
+      max_size: New maximum size.
+      desired: New desired capacity.
+      can_scale_from_zero: When set, overrides the CanScaleFromZero flag.
+    """
+    body = {k: v for k, v in asg.items()
+            if k not in self._READONLY_ASG_FIELDS}
+    body["MinSize"] = min_size
+    body["MaxSize"] = max_size
+    body["DesiredCapacity"] = desired
+    if can_scale_from_zero is not None:
+      body["CanScaleFromZero"] = can_scale_from_zero
+    self.update(body)
+
+  def stop_resources(self, exclude=()):
+    """Scale every ASG to zero, snapshotting prior sizing first.
+
+    Best-effort: each ASG's current MinSize/MaxSize/DesiredCapacity and
+    CanScaleFromZero are stored as a JSON blob in the ASG's custom data
+    before it is scaled to zero, so ``start_resources`` can restore them.
+    An ASG that already carries a snapshot is assumed to be asleep and is
+    left untouched, so a repeated stop never overwrites the snapshot with
+    zeros. Genuine failures are collected and returned rather than
+    aborting the sweep.
+
+    Args:
+      exclude: ASG FriendlyNames to leave running.
+
+    Returns:
+      A list of (name, DuploError) for ASGs that failed to stop.
+    """
+    errors = []
+    for asg in self.list():
+      name = asg["FriendlyName"]
+      if name in exclude:
+        continue
+      already_zero = (str(asg.get("MinSize")) == "0"
+                      and str(asg.get("DesiredCapacity")) == "0")
+      if self._get_custom_data(asg, self._SLEEP_KEY) is not None \
+          and already_zero:
+        # Genuinely asleep already — don't re-snapshot zeros over the
+        # real sizing. A snapshot on a group that is NOT at zero is stale
+        # (a prior stop failed after writing it), so fall through and
+        # re-snapshot the real sizing before retrying the scale-down.
+        continue
+      try:
+        snap = {
+          "MinSize": asg.get("MinSize"),
+          "MaxSize": asg.get("MaxSize"),
+          "DesiredCapacity": asg.get("DesiredCapacity"),
+          "CanScaleFromZero": asg.get("CanScaleFromZero", False),
+        }
+        self._set_custom_data(name, self._SLEEP_KEY, json.dumps(snap))
+        try:
+          # Cluster-autoscaled groups need CanScaleFromZero to sit at zero
+          # nodes; the backend rejects that flag on non-autoscaled groups,
+          # so only enable it where it is allowed.
+          csfz = True if asg.get("IsClusterAutoscaled") else None
+          self._apply_capacity(asg, 0, 0, 0, can_scale_from_zero=csfz)
+        except DuploError:
+          # Roll back the snapshot so a retry re-snapshots real sizing
+          # instead of skipping this group as already asleep.
+          self._set_custom_data(name, self._SLEEP_KEY, "", delete=True)
+          raise
+      except DuploError as e:
+        self.duplo.logger.warning(f"Failed to stop asg '{name}': {e}")
+        errors.append((name, e))
+    return errors
+
+  def start_resources(self, exclude=()):
+    """Restore every asleep ASG from its snapshot, then clear it.
+
+    Mirror of ``stop_resources``. ASGs without a snapshot are skipped
+    (nothing to restore). Genuine failures are collected and returned.
+
+    Args:
+      exclude: ASG FriendlyNames to leave stopped.
+
+    Returns:
+      A list of (name, DuploError) for ASGs that failed to start.
+    """
+    errors = []
+    for asg in self.list():
+      name = asg["FriendlyName"]
+      if name in exclude:
+        continue
+      raw = self._get_custom_data(asg, self._SLEEP_KEY)
+      if raw is None:
+        continue
+      try:
+        snap = json.loads(raw)
+        self._apply_capacity(
+          asg,
+          snap["MinSize"],
+          snap["MaxSize"],
+          snap["DesiredCapacity"],
+          can_scale_from_zero=snap.get("CanScaleFromZero", False),
+        )
+        self._set_custom_data(name, self._SLEEP_KEY, "", delete=True)
+      except (DuploError, ValueError, KeyError) as e:
+        self.duplo.logger.warning(f"Failed to start asg '{name}': {e}")
+        errors.append((name, e))
+    return errors

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -1,10 +1,11 @@
 import json
 
-from duplocloud.controller import DuploCtl
-from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploError, DuploNotFound
+from duplocloud import args
 from duplocloud.commander import Command, Resource
-import duplocloud.args as args
+from duplocloud.controller import DuploCtl
+from duplocloud.errors import DuploError, DuploNotFound
+from duplocloud.resource import DuploResourceV2
+
 
 @Resource("asg", scope="tenant")
 class DuploAsg(DuploResourceV2):

--- a/src/duplo_resource/asg.py
+++ b/src/duplo_resource/asg.py
@@ -322,10 +322,10 @@ class DuploAsg(DuploResourceV2):
     ``UpdateTenantAsgProfile`` validates and applies the *entire*
     submitted profile — omitted fields fall back to defaults. A sparse
     body therefore silently no-ops the capacity change and mis-validates
-    flags such as ``CanScaleFromZero`` (which the backend rejects unless
-    ``IsClusterAutoscaled`` is present and true). So start from the
-    current profile and override only the capacity fields, as the
-    Terraform provider does.
+    flags such as ``CanScaleFromZero`` (which the backend rejects when
+    set to ``true`` unless ``IsClusterAutoscaled`` is present and true;
+    ``false`` is always accepted). So start from the current profile and
+    override only the capacity fields, as the Terraform provider does.
 
     Args:
       asg: The full ASG profile body from ``list``/``find``.
@@ -384,8 +384,9 @@ class DuploAsg(DuploResourceV2):
         self._set_custom_data(name, self._SLEEP_KEY, json.dumps(snap))
         try:
           # Cluster-autoscaled groups need CanScaleFromZero to sit at zero
-          # nodes; the backend rejects that flag on non-autoscaled groups,
-          # so only enable it where it is allowed.
+          # nodes; the backend rejects setting it to true unless
+          # IsClusterAutoscaled is true, so only enable it on autoscaled
+          # groups (setting/leaving it false is always accepted).
           csfz = True if asg.get("IsClusterAutoscaled") else None
           self._apply_capacity(asg, 0, 0, 0, can_scale_from_zero=csfz)
         except DuploError:
@@ -420,6 +421,10 @@ class DuploAsg(DuploResourceV2):
         continue
       try:
         snap = json.loads(raw)
+        # Restore the *original* CanScaleFromZero from the snapshot: stop
+        # may have flipped it to true on an autoscaled group, so start
+        # must set it back. The snapshot value is false for non-autoscaled
+        # groups, which the backend always accepts.
         self._apply_capacity(
           asg,
           snap["MinSize"],

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -1,8 +1,8 @@
+from duplocloud import args
+from duplocloud.commander import Command, Resource
 from duplocloud.controller import DuploCtl
 from duplocloud.errors import DuploError, DuploNotFound, DuploStillWaiting
 from duplocloud.resource import DuploResourceV3
-from duplocloud.commander import Command, Resource
-import duplocloud.args as args
 
 # DBEngine enum values from the backend (RDSConfiguration.cs). Cluster
 # engines (Aurora) support stop/start only at the cluster level, not on

--- a/src/duplo_resource/rds.py
+++ b/src/duplo_resource/rds.py
@@ -290,6 +290,10 @@ class DuploRDS(DuploResourceV3):
       "invaliddbclusterstate",
       "invaliddbinstancestate",
       "is not in available state",
+      # cluster-level equivalent: stopping a cluster that is already
+      # stopped (target state already reached) — e.g. "DbCluster X is in
+      # stopped state but expected it to be one of available."
+      "is in stopped state but expected",
     ))
 
   @Command()

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -708,6 +708,62 @@ class DuploService(DuploResourceV2):
     """
     return self._perform_action("start", name, all, targets, self.duplo.wait)
 
+  def stop_resources(self, exclude=()):
+    """Stop every service in the tenant (for the tenant sweep).
+
+    Lists all services, skips any excluded by name, and stops each via
+    the native ReplicationController suspend endpoint, which preserves
+    the configured replica count (no snapshot needed). Best-effort:
+    failures are collected and returned rather than aborting the sweep.
+
+    Args:
+      exclude: Service names to leave running.
+
+    Returns:
+      A list of (name, DuploError) for services that failed to stop.
+    """
+    return self._sweep_action("Stop", exclude)
+
+  def start_resources(self, exclude=()):
+    """Start every service in the tenant (for the tenant sweep).
+
+    Mirror of ``stop_resources``; resumes each service to its stored
+    replica count.
+
+    Args:
+      exclude: Service names to leave stopped.
+
+    Returns:
+      A list of (name, DuploError) for services that failed to start.
+    """
+    return self._sweep_action("start", exclude)
+
+  def _sweep_action(self, action, exclude=()):
+    """Run ``action`` ("Stop"/"start") across all services.
+
+    Reuses ``_perform_action`` (per-service endpoint call and optional
+    ``--wait``) and adapts its result into the ``(name, DuploError)``
+    failure list the tenant sweep expects from each service type.
+
+    Args:
+      action: Either "Stop" or "start".
+      exclude: Service names to skip.
+
+    Returns:
+      A list of (name, DuploError) for services that failed.
+    """
+    targets = [s["Name"] for s in self.list() if s["Name"] not in exclude]
+    if not targets:
+      return []
+    # Never health-wait here: the per-service wait faults on any pod
+    # fault, and during a tenant sweep the tenant's own nodes are down,
+    # so its pods are always Unschedulable (an expected condition, not a
+    # failure). Stop is effectively instant server-side, and on start the
+    # scheduler places pods once the ASG nodes return.
+    result = self._perform_action(action, targets=targets, wait=False)
+    return [(e["service"], DuploError(e["error"]))
+            for e in result["details"]["errors"]]
+
   @Command()
   def pods(self,
            name: args.NAME) -> dict:

--- a/src/duplo_resource/service.py
+++ b/src/duplo_resource/service.py
@@ -1,10 +1,16 @@
 import time
-from duplocloud.controller import DuploCtl
-from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploError, DuploFailedResource, DuploNotFound, DuploStillWaiting
-from duplocloud.commander import Command, Resource
 from json import dumps, loads
-import duplocloud.args as args
+
+from duplocloud import args
+from duplocloud.commander import Command, Resource
+from duplocloud.controller import DuploCtl
+from duplocloud.errors import (
+  DuploError,
+  DuploFailedResource,
+  DuploNotFound,
+  DuploStillWaiting,
+)
+from duplocloud.resource import DuploResourceV2
 
 _STATUS_CODES = {
   "1": "Running",
@@ -93,8 +99,7 @@ class DuploService(DuploResourceV2):
     for c in containers:
       if c["Name"] == body["Name"]:
         return c["Image"]
-    else:
-      return body.get("DockerImage", body.get("Image", None))
+    return body.get("DockerImage", body.get("Image", None))
 
   @Command()
   def find(self,

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -1,11 +1,13 @@
-from datetime import timedelta
 import datetime
 import time
-from duplocloud.controller import DuploCtl
-from duplocloud.resource import DuploResourceV2
-from duplocloud.errors import DuploError, DuploNotFound, DuploStillWaiting
+from datetime import timedelta
+
+from duplocloud import args
 from duplocloud.commander import Command, Resource
-import duplocloud.args as args
+from duplocloud.controller import DuploCtl
+from duplocloud.errors import DuploError, DuploNotFound, DuploStillWaiting
+from duplocloud.resource import DuploResourceV2
+
 
 @Resource("tenant")
 class DuploTenant(DuploResourceV2):
@@ -686,9 +688,7 @@ class DuploTenant(DuploResourceV2):
       if not name:
         continue
       tags = (host.get("Tags") or []) + (host.get("TagsEx") or [])
-      if any(t.get("Key") == "aws:autoscaling:groupName" for t in tags):
-        managed.add(name)
-      elif any(name == a or name.startswith(f"{a}-") for a in asg_names):
+      if any(t.get("Key") == "aws:autoscaling:groupName" for t in tags) or any(name == a or name.startswith(f"{a}-") for a in asg_names):
         managed.add(name)
     return managed
 

--- a/src/duplo_resource/tenant.py
+++ b/src/duplo_resource/tenant.py
@@ -491,12 +491,14 @@ class DuploTenant(DuploResourceV2):
       exclude (optional): A list of resources to exclude from starting. Can include:
         - hosts/<host_name>: Exclude a specific host.
         - rds/<rds_name>: Exclude a specific RDS instance.
+        - asg/<asg_name>: Exclude a specific Auto Scaling Group.
+        - service/<service_name>: Exclude a specific service.
         - hosts/at/<allocation_tags>: Exclude hosts with specific allocation tags.
 
     Returns:
       message: A success message.
     """
-    service_types = {"hosts": [], "rds": []}
+    service_types = {"hosts": [], "rds": [], "asg": [], "service": []}
     host_at = []
     if exclude:
       for item in exclude:
@@ -504,19 +506,23 @@ class DuploTenant(DuploResourceV2):
         if 'at/' in value:
           _, at_name = value.split('at/', 1)
           host_at.append(at_name)
-        elif category in {"hosts", "rds"}:
+        elif category in {"hosts", "rds", "asg", "service"}:
           tenant_name = self.find(name)['AccountName']
-          if category == "hosts":
+          if category in {"hosts", "asg"}:
             prefix = f"duploservices-{tenant_name}"
             value = f"{prefix}-{value}" if not value.startswith(prefix) else value
           elif category == "rds":
             value = f"duplo{value}" if not value.startswith("duplo") else value
+          # service names are not prefixed; append the raw value
           service_types[category].append(value)
         else:
           print(f"Unknown service: {category}")
 
     host_at_exclude = self.get_hosts_to_exclude(host_at)
-    service_types['hosts'] = list(set(service_types['hosts']) | set(host_at_exclude))
+    service_types['hosts'] = list(
+      set(service_types['hosts'])
+      | set(host_at_exclude)
+      | self._asg_managed_hosts())
 
     self._sweep("start", service_types)
     return {
@@ -541,12 +547,14 @@ class DuploTenant(DuploResourceV2):
       exclude (optional): A list of resources to exclude from stopping. Can include:
         - hosts/<host_name>: Exclude a specific host.
         - rds/<rds_name>: Exclude a specific RDS instance.
+        - asg/<asg_name>: Exclude a specific Auto Scaling Group.
+        - service/<service_name>: Exclude a specific service.
         - hosts/at/<allocation_tags>: Exclude hosts with specific allocation tags.
 
     Returns:
       message: A success message.
     """
-    service_types = {"hosts": [], "rds": []}
+    service_types = {"hosts": [], "rds": [], "asg": [], "service": []}
     host_at = []
     if exclude:
       for item in exclude:
@@ -554,19 +562,23 @@ class DuploTenant(DuploResourceV2):
         if 'at/' in value:
           _, at_name = value.split('at/', 1)
           host_at.append(at_name)
-        elif category in {"hosts", "rds"}:
+        elif category in {"hosts", "rds", "asg", "service"}:
           tenant_name = self.find(name)['AccountName']
-          if category == "hosts":
+          if category in {"hosts", "asg"}:
             prefix = f"duploservices-{tenant_name}"
             value = f"{prefix}-{value}" if not value.startswith(prefix) else value
           elif category == "rds":
             value = f"duplo{value}" if not value.startswith("duplo") else value
+          # service names are not prefixed; append the raw value
           service_types[category].append(value)
         else:
           print(f"Unknown service: {category}")
 
     host_at_exclude = self.get_hosts_to_exclude(host_at)
-    service_types['hosts'] = list(set(service_types['hosts']) | set(host_at_exclude))
+    service_types['hosts'] = list(
+      set(service_types['hosts'])
+      | set(host_at_exclude)
+      | self._asg_managed_hosts())
 
     self._sweep("stop", service_types)
     return {
@@ -576,9 +588,9 @@ class DuploTenant(DuploResourceV2):
   def _sweep(self, action, service_types):
     """Apply ``action`` ("stop"/"start") across all service types.
 
-    Best-effort: every eligible resource is attempted. RDS owns its own
-    engine-aware routing and cluster dedup and returns genuine failures
-    (rather than aborting mid-sweep); hosts are attempted per item.
+    Best-effort: every eligible resource is attempted. RDS, ASG, and
+    services own their own routing and return genuine failures (rather
+    than aborting mid-sweep); hosts are attempted per item.
     Genuine failures from any service type are collected and, if any
     occurred, raised as a single aggregated ``DuploError`` so the command
     exits non-zero instead of falsely reporting success.
@@ -592,13 +604,28 @@ class DuploTenant(DuploResourceV2):
       DuploError: If one or more resources failed for a genuine reason.
     """
     errors = []
-    for service_type in service_types.keys():
+    # Order matters: on stop, drain container services before pulling
+    # their compute; on start, restore compute (and RDS) first so resumed
+    # services have somewhere to schedule (especially under --wait). Any
+    # type absent from service_types is skipped.
+    stop_order = ("service", "hosts", "asg", "rds")
+    start_order = ("hosts", "asg", "rds", "service")
+    order = stop_order if action == "stop" else start_order
+    for service_type in order:
+      if service_type not in service_types:
+        continue
       service = self.duplo.load(service_type)
       excluded = service_types[service_type]
-      if service_type == "rds":
-        # RDS routes Aurora/cluster engines to the cluster endpoint
-        # (deduped per cluster), skips Serverless v1/DocDB, treats
-        # already-in-state errors as benign, and returns genuine failures.
+      if service_type in ("rds", "asg", "service"):
+        # RDS, ASG, and services own their own sweep logic and return a
+        # list of (name, error) for genuine failures rather than aborting
+        # mid-sweep. RDS routes Aurora/cluster engines to the cluster
+        # endpoint (deduped per cluster), skips Serverless v1/DocDB, and
+        # treats already-in-state errors as benign. ASG snapshots each
+        # group's sizing into custom data before scaling it to zero, and
+        # restores from that snapshot on start. Services use the native
+        # ReplicationController suspend/resume, which preserves the
+        # configured replica count.
         errors.extend(getattr(service, f"{action}_resources")(exclude=excluded))
         continue
       for item in service.list():
@@ -617,9 +644,9 @@ class DuploTenant(DuploResourceV2):
             )
             errors.append((service_name, e))
     if errors:
-      summary = "; ".join(f"{name}: {e}" for name, e in errors)
+      summary = "\n".join(f"  - {name}: {e}" for name, e in errors)
       raise DuploError(
-        f"Failed to {action} {len(errors)} resource(s): {summary}",
+        f"Failed to {action} {len(errors)} resource(s):\n{summary}",
         errors[0][1].code
       )
 
@@ -636,6 +663,34 @@ class DuploTenant(DuploResourceV2):
       if allocation_tags_value in host_at:
         host_at_exclude.append(host['FriendlyName'])
     return host_at_exclude
+
+  def _asg_managed_hosts(self):
+    """FriendlyNames of hosts whose lifecycle an ASG owns.
+
+    The ASG sweep scales groups to zero, which terminates their
+    instances. Those instances also appear in the native-host list, so
+    without this exclusion the host sweep issues a per-instance stop that
+    the ASG immediately relaunches (churn) before the ASG sweep scales it
+    to zero. A host is treated as ASG-managed if it carries the
+    ``aws:autoscaling:groupName`` tag, or, as a fallback, its
+    FriendlyName matches an ASG's (Duplo names an ASG's instances after
+    the group).
+
+    Returns:
+      A set of host FriendlyNames to exclude from the host sweep.
+    """
+    asg_names = [a["FriendlyName"] for a in self.duplo.load("asg").list()]
+    managed = set()
+    for host in self.duplo.load("hosts").list():
+      name = host.get("FriendlyName")
+      if not name:
+        continue
+      tags = (host.get("Tags") or []) + (host.get("TagsEx") or [])
+      if any(t.get("Key") == "aws:autoscaling:groupName" for t in tags):
+        managed.add(name)
+      elif any(name == a or name.startswith(f"{a}-") for a in asg_names):
+        managed.add(name)
+    return managed
 
   @Command()
   def dns_config(self, 

--- a/src/tests/test_asg.py
+++ b/src/tests/test_asg.py
@@ -1,5 +1,7 @@
+import json
 import pytest
 import time
+from unittest.mock import MagicMock
 from duplocloud.errors import DuploError
 from .conftest import get_test_data
 
@@ -123,3 +125,125 @@ class TestAsg:
         r, _ = asg_resource
         response = execute_test(r.delete, "duploctl")
         assert "Successfully deleted asg" in response["message"]
+
+
+# ---------------------------------------------------------------------------
+# stop_resources() / start_resources() — snapshot, scale-to-zero, restore
+# ---------------------------------------------------------------------------
+
+def _make_asg(mocker):
+    """Return a DuploAsg with a mocked client and pinned tenant."""
+    from duplo_resource.asg import DuploAsg
+    duplo = MagicMock()
+    duplo.wait = False
+    resource = DuploAsg(duplo)
+    resource.client = MagicMock()
+    resource._tenant = {"TenantId": "tid-1", "AccountName": "mytenant"}
+    resource._tenant_id = "tid-1"
+    return resource
+
+
+def _asg_body(min_size=2, max_size=3, desired=3, autoscaled=False,
+              snapshot=None):
+    body = {
+        "FriendlyName": "duploservices-mytenant-apps",
+        "MinSize": min_size, "MaxSize": max_size,
+        "DesiredCapacity": desired, "IsClusterAutoscaled": autoscaled,
+        "CanScaleFromZero": False, "CustomDataTags": [],
+    }
+    if snapshot is not None:
+        body["CustomDataTags"] = [
+            {"Key": "DuploctlSleepState", "Value": snapshot}]
+    return body
+
+
+_SNAP = json.dumps({"MinSize": 2, "MaxSize": 3, "DesiredCapacity": 3,
+                    "CanScaleFromZero": False})
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_stop_resources_snapshots_then_scales_to_zero(mocker):
+    r = _make_asg(mocker)
+    mocker.patch.object(r, "list", return_value=[_asg_body()])
+    set_cd = mocker.patch.object(r, "_set_custom_data")
+    apply = mocker.patch.object(r, "_apply_capacity")
+
+    errors = r.stop_resources()
+
+    assert errors == []
+    assert set_cd.call_args.args[1] == r._SLEEP_KEY
+    assert json.loads(set_cd.call_args.args[2]) == {
+        "MinSize": 2, "MaxSize": 3, "DesiredCapacity": 3,
+        "CanScaleFromZero": False}
+    # non-autoscaled group: CanScaleFromZero left untouched
+    apply.assert_called_once_with(_asg_body(), 0, 0, 0,
+                                  can_scale_from_zero=None)
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_stop_resources_enables_scale_from_zero_when_autoscaled(mocker):
+    r = _make_asg(mocker)
+    mocker.patch.object(r, "list", return_value=[_asg_body(autoscaled=True)])
+    mocker.patch.object(r, "_set_custom_data")
+    apply = mocker.patch.object(r, "_apply_capacity")
+
+    r.stop_resources()
+
+    assert apply.call_args.kwargs["can_scale_from_zero"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_stop_resources_skips_group_already_at_zero(mocker):
+    r = _make_asg(mocker)
+    asleep = _asg_body(min_size=0, max_size=0, desired=0, snapshot=_SNAP)
+    mocker.patch.object(r, "list", return_value=[asleep])
+    set_cd = mocker.patch.object(r, "_set_custom_data")
+    apply = mocker.patch.object(r, "_apply_capacity")
+
+    assert r.stop_resources() == []
+    set_cd.assert_not_called()
+    apply.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_stop_resources_rolls_back_snapshot_on_scale_failure(mocker):
+    r = _make_asg(mocker)
+    mocker.patch.object(r, "list", return_value=[_asg_body()])
+    set_cd = mocker.patch.object(r, "_set_custom_data")
+    mocker.patch.object(r, "_apply_capacity",
+                        side_effect=DuploError("nope", 400))
+
+    errors = r.stop_resources()
+
+    assert len(errors) == 1
+    # the snapshot written before the failed scale is rolled back
+    assert any(c.kwargs.get("delete") for c in set_cd.call_args_list)
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_start_resources_restores_snapshot_then_clears(mocker):
+    r = _make_asg(mocker)
+    body = _asg_body(min_size=0, max_size=0, desired=0, snapshot=_SNAP)
+    mocker.patch.object(r, "list", return_value=[body])
+    apply = mocker.patch.object(r, "_apply_capacity")
+    set_cd = mocker.patch.object(r, "_set_custom_data")
+
+    assert r.start_resources() == []
+    apply.assert_called_once_with(body, 2, 3, 3, can_scale_from_zero=False)
+    assert any(c.kwargs.get("delete") for c in set_cd.call_args_list)
+
+
+@pytest.mark.unit
+@pytest.mark.asg
+def test_asg_start_resources_skips_without_snapshot(mocker):
+    r = _make_asg(mocker)
+    mocker.patch.object(r, "list", return_value=[_asg_body()])
+    apply = mocker.patch.object(r, "_apply_capacity")
+
+    assert r.start_resources() == []
+    apply.assert_not_called()

--- a/src/tests/test_asg.py
+++ b/src/tests/test_asg.py
@@ -1,9 +1,13 @@
 import json
-import pytest
 import time
 from unittest.mock import MagicMock
+
+import pytest
+
 from duplocloud.errors import DuploError
+
 from .conftest import get_test_data
+
 
 @pytest.fixture(scope="class")
 def asg_resource(duplo):

--- a/src/tests/test_rds.py
+++ b/src/tests/test_rds.py
@@ -1,7 +1,10 @@
-import pytest
 import time
 from unittest.mock import MagicMock
+
+import pytest
+
 from duplocloud.errors import DuploError, DuploStillWaiting
+
 from .conftest import get_test_data
 
 

--- a/src/tests/test_rds.py
+++ b/src/tests/test_rds.py
@@ -315,6 +315,24 @@ def test_stop_resources_swallows_benign_state_error(mocker):
 
 @pytest.mark.unit
 @pytest.mark.rds
+def test_is_benign_state_error_matches_already_stopped_cluster(mocker):
+    """Stopping an already-stopped cluster is benign (target state reached).
+
+    The instance-level wording was already covered; this pins the
+    cluster-level 'is in stopped state but expected …' message so a
+    re-run of stop on a stopped cluster is skipped, not failed.
+    """
+    r = _make_rds(mocker)
+    already_stopped = DuploError(
+        '{"Message":"DbCluster duplo-shared-cluster is in stopped state '
+        'but expected it to be one of available."}', 400)
+    genuine = DuploError('{"Message":"Internal server error"}', 500)
+    assert r._is_benign_state_error(already_stopped) is True
+    assert r._is_benign_state_error(genuine) is False
+
+
+@pytest.mark.unit
+@pytest.mark.rds
 def test_stop_resources_collects_genuine_error_and_continues(mocker):
     """A genuine (non-benign, non-transient) error is collected; sweep continues."""
     r = _make_rds(mocker)

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -1,8 +1,11 @@
 import json
-import pytest
 from unittest.mock import ANY
+
+import pytest
+
 from duplo_resource.service import DuploService
 from duplocloud.errors import DuploError, DuploNotFound
+
 
 @pytest.mark.unit
 def test_create_service(mocker):

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -202,3 +202,30 @@ def test_update_env_empty_otherdockerconfig(mocker):
   posted_body = mock_client.post.call_args[0][1]
   config = json.loads(posted_body["OtherDockerConfig"])
   assert config["Env"] == [{"Name": "MY_VAR", "Value": "val"}]
+
+
+@pytest.mark.unit
+def test_service_stop_resources_forces_no_wait_and_maps_errors(mocker):
+    """The tenant-sweep entry point never health-waits and returns tuples.
+
+    Health-waiting would fault on Unschedulable pods (expected while the
+    tenant's nodes are down), so the sweep must force wait off even when
+    the global --wait flag is set, and adapt errors into (name, error).
+    """
+    mock_client = mocker.MagicMock()
+    mock_client.load_client.return_value = mock_client
+    mock_client.wait = True  # global --wait on; sweep must still not wait
+    service = DuploService(mock_client)
+    mocker.patch.object(service, "list", return_value=[
+        {"Name": "keep"}, {"Name": "skip"}])
+    perform = mocker.patch.object(
+        service, "_perform_action",
+        return_value={"details": {"errors": [
+            {"service": "keep", "error": "boom"}]}})
+
+    errors = service.stop_resources(exclude=["skip"])
+
+    perform.assert_called_once_with("Stop", targets=["keep"], wait=False)
+    assert len(errors) == 1
+    assert errors[0][0] == "keep"
+    assert isinstance(errors[0][1], DuploError)

--- a/src/tests/test_tenant.py
+++ b/src/tests/test_tenant.py
@@ -1,13 +1,14 @@
 import argparse
-
-import pytest
 import time
 from unittest.mock import MagicMock
 
+import pytest
+
+from duplocloud.argtype import ALLOWED_METADATA_TYPES, MetadataAction
 from duplocloud.controller import DuploCtl
 from duplocloud.errors import DuploError
-from duplocloud.argtype import MetadataAction, ALLOWED_METADATA_TYPES
 from tests.conftest import get_test_data
+
 
 @pytest.mark.integration
 @pytest.mark.lifecycle
@@ -126,8 +127,8 @@ class TestTenant:
 @pytest.mark.unit
 def test_tenant_create_model_annotation():
   """create command on DuploTenant is annotated with the AddTenantRequest model"""
-  from duplocloud.commander import get_command_schema
   from duplo_resource.tenant import DuploTenant
+  from duplocloud.commander import get_command_schema
   cmd = get_command_schema(DuploTenant, "create")
   assert cmd["model"] == "AddTenantRequest"
 

--- a/src/tests/test_tenant.py
+++ b/src/tests/test_tenant.py
@@ -447,11 +447,27 @@ def test_tenant_delete_no_force_skips_metadata(mocker):
 # stop() / start() — RDS delegation and per-host resilience
 # ---------------------------------------------------------------------------
 
-def _load_services(resource, hosts, rds):
-  """Wire ``duplo.load`` to return the given hosts/rds service mocks."""
+def _load_services(resource, hosts, rds, asg=None, service=None):
+  """Wire ``duplo.load`` to return service mocks per resource type.
+
+  ``hosts``/``rds`` are required; ``asg``/``service`` default to empty
+  mocks so the ordered sweep and ``_asg_managed_hosts`` have something
+  to iterate. Returns the asg/service mocks for assertions.
+  """
+  if asg is None:
+    asg = MagicMock()
+    asg.list.return_value = []
+    asg.stop_resources.return_value = []
+    asg.start_resources.return_value = []
+  if service is None:
+    service = MagicMock()
+    service.list.return_value = []
+    service.stop_resources.return_value = []
+    service.start_resources.return_value = []
   resource.duplo.load.side_effect = lambda kind: {
-      "hosts": hosts, "rds": rds
+      "hosts": hosts, "rds": rds, "asg": asg, "service": service
   }[kind]
+  return asg, service
 
 
 @pytest.mark.unit
@@ -540,3 +556,83 @@ def test_tenant_stop_raises_when_rds_reports_genuine_failure(mocker):
 
   assert "duplodb1" in str(exc.value)
   assert exc.value.code == 500
+
+
+@pytest.mark.unit
+def test_tenant_stop_delegates_asg_and_service(mocker):
+  """stop() delegates the ASG and service sweeps to their *_resources."""
+  resource = _make_tenant_resource(mocker)
+  hosts = MagicMock()
+  hosts.list.return_value = []
+  rds = MagicMock()
+  rds.stop_resources.return_value = []
+  asg, service = _load_services(resource, hosts, rds)
+
+  resource.stop()
+
+  asg.stop_resources.assert_called_once_with(exclude=[])
+  service.stop_resources.assert_called_once_with(exclude=[])
+
+
+@pytest.mark.unit
+def test_tenant_start_delegates_asg_and_service(mocker):
+  """start() delegates the ASG and service sweeps to their *_resources."""
+  resource = _make_tenant_resource(mocker)
+  hosts = MagicMock()
+  hosts.list.return_value = []
+  rds = MagicMock()
+  rds.start_resources.return_value = []
+  asg, service = _load_services(resource, hosts, rds)
+
+  resource.start()
+
+  asg.start_resources.assert_called_once_with(exclude=[])
+  service.start_resources.assert_called_once_with(exclude=[])
+
+
+@pytest.mark.unit
+def test_tenant_stop_excludes_asg_managed_hosts(mocker):
+  """Hosts tagged aws:autoscaling:groupName are skipped by the host sweep.
+
+  The ASG owns their lifecycle (scale-to-zero), so the per-host stop must
+  not touch them — otherwise the group relaunches the instances (churn).
+  """
+  resource = _make_tenant_resource(mocker)
+  hosts = MagicMock()
+  hosts.list.return_value = [
+      {"FriendlyName": "duploservices-mytenant-standalone",
+       "MinionTags": [], "Tags": []},
+      {"FriendlyName": "duploservices-mytenant-apps", "MinionTags": [],
+       "Tags": [{"Key": "aws:autoscaling:groupName",
+                 "Value": "duploservices-mytenant-apps"}]},
+  ]
+  hosts.name_from_body.side_effect = lambda b: b["FriendlyName"]
+  rds = MagicMock()
+  rds.stop_resources.return_value = []
+  _load_services(resource, hosts, rds)
+
+  resource.stop()
+
+  stopped = [c.args[0] for c in hosts.stop.call_args_list]
+  assert "duploservices-mytenant-standalone" in stopped
+  assert "duploservices-mytenant-apps" not in stopped
+
+
+@pytest.mark.unit
+def test_tenant_stop_exclude_parsing(mocker):
+  """--exclude routes each category to the right sweep with prefixed names."""
+  resource = _make_tenant_resource(mocker)
+  hosts = MagicMock()
+  hosts.list.return_value = []
+  rds = MagicMock()
+  rds.stop_resources.return_value = []
+  asg, service = _load_services(resource, hosts, rds)
+
+  resource.stop(exclude=["asg/apps", "service/admin", "rds/db1"])
+
+  # asg names get the tenant prefix; rds gets the "duplo" prefix; service
+  # names are used verbatim.
+  asg.stop_resources.assert_called_once_with(
+      exclude=["duploservices-mytenant-apps"])
+  service.stop_resources.assert_called_once_with(exclude=["admin"])
+  rds.stop_resources.assert_called_once_with(exclude=["duplodb1"])


### PR DESCRIPTION
## Describe Changes

Extends `tenant stop` / `tenant start` to actually park a tenant, not just native hosts + RDS.

- **ASGs** are scaled to zero on stop and restored on start. Each group's prior `MinSize`/`MaxSize`/`DesiredCapacity` (and `CanScaleFromZero`) is snapshotted into the ASG's custom data (`DuploctlSleepState`) before scaling down, then restored and cleared on start. The update sends the **full** profile to `UpdateTenantAsgProfile` (a sparse body silently no-ops the capacity change and mis-validates flags). `CanScaleFromZero` is only set on cluster-autoscaled groups, since the backend rejects it otherwise.
- **ASG-managed hosts are excluded from the native-host sweep** (detected via the `aws:autoscaling:groupName` tag, falling back to the ASG naming convention), so the group scales them down instead of the host sweep stopping instances the ASG would immediately relaunch (churn).
- **ReplicationController services** (k8s and native Docker; **ECS is out of scope**) are stopped/started via the platform's native `ReplicationController` suspend/resume. Replica counts are preserved by the backend, so no snapshot is needed.
- **Sweep ordering is action-aware**: on stop, services drain before their compute is pulled (`service → hosts → asg → rds`); on start, compute and RDS are restored before services resume (`hosts → asg → rds → service`).
- **RDS**: an already-stopped Aurora/cluster is now treated as benign (the benign-state check also matches the cluster-level `is in stopped state but expected …` wording), instead of failing the sweep — matching the existing instance-level behavior.
- New `--exclude` selectors: `asg/<name>` and `service/<name>`.
- Aggregated sweep failures are now printed one per line.

## Link to Issues

[DUPLO-43791](https://app.clickup.com/t/8655600/DUPLO-43791)

## PR Review Checklist

- [x] Thoroughly reviewed on local machine. Verified end-to-end against the `dev01` tenant: ASGs park to `0/0` and restore to prior sizing; ASG hosts no longer churn; RC services stop (`replicas: 0`) and start restores replica counts natively; already-stopped RDS clusters skip benignly; both commands exit `0`.
- [x] Have you added any tests — unit tests for the new sweep wiring: ASG snapshot/scale-to-zero/restore/rollback and skip-already-zero (`test_asg.py`), service `_sweep_action` forcing no-wait + error mapping (`test_service.py`), ASG/service delegation, ASG-managed-host exclusion, and `--exclude` parsing (`test_tenant.py`), and the already-stopped-cluster benign case (`test_rds.py`). Backend-contract behavior (full-profile scale, native replica restore) is covered by the live dev01 verification above.
- [x] Make sure to note changes in Changelog.
