### PR TITLE
fix: job create wait deadlock on completed jobs and pod logs KeyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `job create --wait` no longer times out on jobs that completed after their pods left the pod listing — terminal `Complete`/`Failed` conditions are now checked before pod-count consistency
+- `pod logs` no longer crashes with `KeyError: 'Data'` when the backend returns no log data for a running pod
+
 ## [0.4.5] - 2026-07-20
 
 ### Fixed

--- a/src/duplo_resource/job.py
+++ b/src/duplo_resource/job.py
@@ -85,6 +85,13 @@ class DuploJob(DuploResourceV3):
         s = succeeded
         f = failed
         self.duplo.logger.warning(f"Job {name}: active({active}/{completions}), succeeded({succeeded}/{completions}), failed({failed}/{limit})")
+      # Terminal conditions come first: completed pods may already be
+      # gone from the pod listing, so gating these on pod counts can
+      # spin forever on a job that has actually finished.
+      if len(fail) > 0:
+        raise DuploFailedResource(f"Job {name} failed with {fail[0]['reason']}: {fail[0]['message']}")
+      if len(cpl) > 0:
+        return
       # make sure we can get pods and logs first
       pods_exist = (active > 0 or succeeded > 0 or failed > 0)
       pods = self.pods(name)
@@ -100,12 +107,8 @@ class DuploJob(DuploResourceV3):
       pod_count = active + succeeded + failed
       if podct != pod_count:
         raise DuploStillWaiting(f"Expected {pod_count} pods, got {podct}")
-      if len(fail) > 0:
-        raise DuploFailedResource(f"Job {name} failed with {fail[0]['reason']}: {fail[0]['message']}")
-      
-      # if none have completed, keep waiting
-      if not len(cpl) > 0:
-        raise DuploStillWaiting(f"Job '{name}' is waiting for 'Complete' condition")
+      # none have completed yet, keep waiting
+      raise DuploStillWaiting(f"Job '{name}' is waiting for 'Complete' condition")
     super().create(body, wait_check)
     return {
       "message": f"Job {name} ran successfully."

--- a/src/duplo_resource/pod.py
+++ b/src/duplo_resource/pod.py
@@ -53,7 +53,12 @@ class DuploPod(DuploResourceV2):
     }
     response = self.client.post(self.endpoint("findContainerLogs"), data)
     o = response.json()
-    lines = o["Data"].split("\n")
+    # A running pod may have no retrievable logs yet, in which case the
+    # backend omits the Data key entirely.
+    logs = o.get("Data")
+    if logs is None:
+      return None
+    lines = logs.split("\n")
     if lines[-1] == "":
       lines.pop()
     last = self.__last_lines.get(id, 0)

--- a/src/tests/test_job_wait.py
+++ b/src/tests/test_job_wait.py
@@ -1,0 +1,88 @@
+import pytest
+
+from duplo_resource.job import DuploJob
+from duplo_resource.pod import DuploPod
+from duplocloud.errors import DuploFailedResource, DuploStillWaiting
+
+
+def _make_job(mocker, status):
+    """Create a DuploJob with a mocked duplo client and a fixed find() status."""
+    mock_duplo = mocker.MagicMock()
+    mock_duplo.wait = True
+    mock_duplo.wait_timeout = 3  # keep the wait loop to a single iteration
+    job = DuploJob(mock_duplo)
+    job._tenant = {"AccountName": "myaccount", "TenantId": "tid-123"}
+    job._tenant_id = "tid-123"
+    mocker.patch.object(job, "client", mocker.MagicMock())
+    mocker.patch.object(job, "find", return_value={
+        "status": status,
+        "spec": {"completions": 4, "backoffLimit": 6},
+    })
+    return job
+
+
+_JOB_BODY = {"metadata": {"name": "duploctl"}}
+
+
+@pytest.mark.unit
+def test_create_succeeds_on_complete_even_without_pods(mocker):
+    """A Complete job must succeed even if its pods are gone from the listing."""
+    job = _make_job(mocker, status={
+        "active": 0, "succeeded": 4, "failed": 0,
+        "conditions": [{"type": "Complete", "status": "True"}],
+    })
+    # completed pods dropped from the listing — this used to spin until timeout
+    mocker.patch.object(job, "pods", return_value=[])
+
+    result = job.create(_JOB_BODY)
+
+    assert "ran successfully" in result["message"]
+
+
+@pytest.mark.unit
+def test_create_fails_fast_on_failed_condition(mocker):
+    job = _make_job(mocker, status={
+        "active": 0, "succeeded": 0, "failed": 4,
+        "conditions": [{
+            "type": "Failed", "status": "True",
+            "reason": "BackoffLimitExceeded", "message": "too many retries",
+        }],
+    })
+    mocker.patch.object(job, "pods", return_value=[])
+
+    with pytest.raises(DuploFailedResource, match="BackoffLimitExceeded"):
+        job.create(_JOB_BODY)
+
+
+@pytest.mark.unit
+def test_create_still_waits_while_running(mocker):
+    job = _make_job(mocker, status={
+        "active": 2, "succeeded": 0, "failed": 0, "conditions": [],
+    })
+    mocker.patch.object(job, "pods", return_value=[])
+    mocker.patch("time.sleep")
+
+    with pytest.raises(DuploStillWaiting):
+        job.create(_JOB_BODY)
+
+
+@pytest.mark.unit
+def test_pod_logs_handles_missing_data_key(mocker):
+    """findContainerLogs may return no Data key for a pod without logs yet."""
+    mock_duplo = mocker.MagicMock()
+    pod_svc = DuploPod(mock_duplo)
+    pod_svc._tenant = {"AccountName": "myaccount", "TenantId": "tid-123"}
+    pod_svc._tenant_id = "tid-123"
+    mock_client = mocker.MagicMock()
+    mock_client.post.return_value.json.return_value = {}
+    mocker.patch.object(pod_svc, "client", mock_client)
+
+    result = pod_svc.logs(pod={
+        "CurrentStatus": 1,
+        "Host": "host1",
+        "InstanceId": "duploctl-abc12",
+        "Containers": [{"DockerId": "docker-1"}],
+    })
+
+    assert result is None
+    mock_client.post.assert_called_once()


### PR DESCRIPTION
## Describe Changes

Fixes the two `test_job.py::test_create_job` integration failures from QA runs [30356825970](https://github.com/duplocloud/duploctl/actions/runs/30356825970) (timeout) and [30362664576](https://github.com/duplocloud/duploctl/actions/runs/30362664576) (`KeyError: 'Data'`):

1. **`job create --wait` could never see a finished job** — the wait check required the live pod listing to match `active + succeeded + failed` before ever looking at the job's conditions. The backend drops completed pods from the pod listing, so a job that finished kept raising `DuploStillWaiting` until timeout. Terminal `Complete`/`Failed` conditions are now checked first.

2. **`pod logs` crashed on a pod with no retrievable logs** — `findContainerLogs` can return a response without a `Data` key; the code indexed it unconditionally, and since `wait()` only retries `DuploStillWaiting`/`DuploConnectionError`, the raw `KeyError` aborted the whole create. Now guarded.

Unit tests added for both regressions (verified they fail against the previous code). Validation k8s suite run dispatched from this branch.

## Link to Issues  

https://app.clickup.com/t/8655600/DUPLO-43827

## PR Review Checklist  

- [x] Thoroughly reviewed on local machine.
- [x] Have you added any tests
- [x] Make sure to note changes in Changelog
