### PR TITLE
chore: pin ruff lint select to E/F, unpin ruff version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tenant stop`/`start` now also stop/start ReplicationController services (k8s and native Docker, not ECS); the platform preserves replica counts. Exclude with `--exclude service/<name>`.
 - `tenant stop` treats an already-stopped Aurora cluster as benign instead of a failure.
 
+### Changed
+
+- Pinned ruff's lint `select` to the historical `E`/`F` default so ruff version bumps no longer silently change enforced rules; unpinned the ruff version.
+
 ## [0.4.5] - 2026-07-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ test = [
   # hook signature that pytest 9.1 removed, which crashes plugin registration.
   # Pin below 9.1 until pytest-black/pytest-isort are dropped in favor of ruff.
   "pytest<9.1",
-  # ruff 0.16 enabled new rules (I001/PLR0402/RUF015/...) that flag many
-  # pre-existing files. Pin below 0.16 until the tree is cleaned up.
-  "ruff<0.16",
+  "ruff",
   "pip-audit",
   "pytest-cov",
   "pytest-dependency",
@@ -134,10 +132,17 @@ omit = [
 
 [tool.ruff]
 exclude = [
-  "**/*_test.py", 
+  "**/*_test.py",
   "**/test_*.py",
   "src/tests/*"
 ]
+
+[tool.ruff.lint]
+# Pin the rule set explicitly. ruff's implicit default expands over time
+# (0.16 turned on B/UP/I/PL/RUF/DTZ/... by default), which silently breaks
+# CI on a version bump. Selecting the historical E/F default keeps linting
+# stable; broaden this deliberately rather than inheriting ruff's defaults.
+select = ["E4", "E7", "E9", "F"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
## Describe Changes

**Root cause:** the repo had no explicit ruff `select`, so linting floated on ruff's implicit default. ruff 0.16 broadened that default substantially (turned on `B`/`UP`/`I`/`PL`/`RUF`/`DTZ`/… by default). Same config, same tree: 0.15 flagged 2, 0.16 flagged ~190 — which is why #275 had to pin `ruff<0.16` to keep CI green.

This makes the rule set explicit instead of inherited:

- Pin `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]` — the historical `E`/`F` default. The enforced rules no longer change when ruff's defaults change, so a future ruff release can't silently break CI again.
- Unpin the ruff version (`ruff<0.16` → `ruff`).

`ruff check ./src` passes under ruff 0.16 with **no code changes**.

**Deliberately out of scope:** adopting 0.16's new rule families (bugbear, pyupgrade, isort, pylint, …). That's an intentional decision, not something to inherit by accident — broaden `select` when the team wants those rules and fix/ignore each on purpose.

## Link to Issues

Follow-up to #275.

## PR Review Checklist

- [x] Thoroughly reviewed on local machine. `ruff check ./src` passes under ruff 0.16 with the explicit select; `src` is unchanged so the unit suite is unchanged from `main`.
- [ ] Have you added any tests — n/a, lint-config only.
- [x] Make sure to note changes in Changelog.
